### PR TITLE
ci(terraform): Replace plan and apply job with reusable workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @3ware/repo-maintainers

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,0 +1,4 @@
+reviewers:
+  # The default reviewers
+  defaults:
+    - team:repo-maintainers # GitHub team

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,4 +1,0 @@
-reviewers:
-  # The default reviewers
-  defaults:
-    - team:repo-maintainers # GitHub team

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -178,20 +178,22 @@ jobs:
       provider-credentials: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
       backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
 
-  # plan-and-apply-prod:
-  #   name: Terraform Deploy Production
-  #   permissions:
-  #     actions: read # Required to download repository artifact.
-  #     checks: write # Required to add status summary.
-  #     contents: read # Required to checkout repository.
-  #     id-token: write # Required to authenticate via OIDC.
-  #     issues: write # Required to create workflow failure issues.
-  #     pull-requests: write # Required to add PR comment and label.
-  #   uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
-  #   with:
-  #     environment: production
-  #     auto-approve-apply: false
-  #     test-destroy: false
-  #   secrets:
-  #     provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
-  #     backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+  # TODO: How to trigger? PR review, PR comment, deployment status?
+  plan-and-apply-prod:
+    name: Terraform Deploy Production
+    permissions:
+      actions: read # Required to download repository artifact.
+      checks: write # Required to add status summary.
+      contents: read # Required to checkout repository.
+      id-token: write # Required to authenticate via OIDC.
+      issues: write # Required to create workflow failure issues.
+      pull-requests: write # Required to add PR comment and label.
+    uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
+    with:
+      environment: production
+      auto-approve-apply: false
+      test-destroy: false
+      region: us-east-1
+    secrets:
+      provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
+      backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -3,11 +3,11 @@ name: Terraform CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, edited, synchronize]
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
       - "**/*.tftpl"
-  #TODO: Trigger to run apply on comment
 
 # Disable permissions for all available scopes.
 permissions: {}
@@ -158,10 +158,9 @@ jobs:
             #### Terraform Validation ${{ steps.tf-validate.outcome }} :white_check_mark:
             #### TFLint ${{ steps.tf-validate.outcome }} :white_check_mark:
 
-  plan-and-apply:
-    name: Terraform Deploy
+  plan-and-apply-dev:
+    name: Terraform Deploy Development
     needs: [test-terraform]
-    runs-on: ubuntu-latest
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.
@@ -169,110 +168,30 @@ jobs:
       id-token: write # Required to authenticate via OIDC.
       issues: write # Required to create workflow failure issues.
       pull-requests: write # Required to add PR comment and label.
+    uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
+    with:
+      environment: development
+      auto-approve-apply: true
+      test-destroy: true
+      region: us-east-1
+    secrets:
+      provider-credentials: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+      backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
 
-    env:
-      TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      #TODO: Construct via inputs and context info in reusable workflow
-      TF_WORKSPACE: mtc-gitops-aws-us-east-1-development
-
-    environment: development
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
-          role-session-name: gitops-2024-terraform-deploy
-
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          # TODO: Add tfswitch or other to read value from terraform block
-          terraform_version: 1.9.7
-          terraform_wrapper: true
-
-      - name: Plan
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
-        with:
-          arg_chdir: terraform
-          arg_command: plan
-          arg_lock: false
-          arg_out: tfplan-${{ github.head_ref}}-PR${{ github.event.pull_request.number}}-out
-          arg_var_file: development.tfvars
-
-      # TODO: Add pr comment explaining what to do run trigger apply
-      # TODO: Add label tf:plan-approved to PR on approval
-
-      - name: Apply
-        # TODO: Run when approved via comment
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
-        with:
-          arg_chdir: terraform
-          arg_command: apply
-          arg_auto_approve: true
-          arg_lock: true
-          arg_var_file: development.tfvars
-
-      # This plan should not produce a diff
-      - name: Check idempotency
-        id: idempotency
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
-        with:
-          arg_chdir: terraform
-          arg_command: plan
-          arg_lock: false
-          arg_detailed_exitcode: true
-          arg_out: tfplan-${{ github.head_ref}}-PR${{ github.event.pull_request.number}}-check # Give this plan a different name
-          arg_var_file: development.tfvars
-
-      - name: Create Issue
-        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-        uses: dacbd/create-issue-action@main
-        with:
-          token: ${{ github.token }}
-          # TODO: use jobs.<job-id>.environment when reusable; context not available here
-          title: ${{ github.workflow }} detected diff during deployment to **PLACEHOLDER** environment
-          body: |
-            ${{ github.workflow }} workflow run [${{ github.run_id }}](https://github.com/3ware/gitops-2024/actions/runs/11378822294) produced a diff when run via pull request #${{ github.event.pull_request.number }}.
-
-            <details>
-            <summary>Outline of changes:</summary>
-            <br>
-
-            ```
-            ${{ steps.idempotency.outputs.outline }}
-            ```
-
-            </details>
-
-            <details>
-            <summary>${{ steps.idempotency.outputs.summary }}</summary>
-            <br>
-
-            ```
-            ${{ steps.idempotency.outputs.last_result }}
-            ```
-
-            </details>
-
-          labels: tf:diff
-
-      - name: Destroy
-        # TODO: Only run in dev
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
-        with:
-          arg_chdir: terraform
-          arg_command: apply
-          arg_auto_approve: true
-          arg_destroy: true
-          arg_lock: true
-          arg_var_file: development.tfvars
-
-      - name: Diff Error
-        if: ${{ steps.idempotency.outputs.exitcode != 0 }}
-        run: |
-          exit 1
+  # plan-and-apply-prod:
+  #   name: Terraform Deploy Production
+  #   permissions:
+  #     actions: read # Required to download repository artifact.
+  #     checks: write # Required to add status summary.
+  #     contents: read # Required to checkout repository.
+  #     id-token: write # Required to authenticate via OIDC.
+  #     issues: write # Required to create workflow failure issues.
+  #     pull-requests: write # Required to add PR comment and label.
+  #   uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
+  #   with:
+  #     environment: production
+  #     auto-approve-apply: false
+  #     test-destroy: false
+  #   secrets:
+  #     provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
+  #     backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -192,8 +192,8 @@ jobs:
     uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
     with:
       environment: production
-      auto-approve-apply: false
-      test-destroy: false
+      #auto-approve-apply: false
+      #test-destroy: false
       region: us-east-1
     secrets:
       provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -159,7 +159,7 @@ jobs:
             #### TFLint ${{ steps.tf-validate.outcome }} :white_check_mark:
 
   plan-and-apply-dev:
-    name: Terraform Deploy Development
+    name: Terraform Deploy
     needs: [test-terraform]
     permissions:
       actions: read # Required to download repository artifact.
@@ -180,7 +180,7 @@ jobs:
 
   # TODO: How to trigger? PR review, PR comment, deployment status?
   plan-and-apply-prod:
-    name: Terraform Deploy Production
+    name: Terraform Deploy
     needs: [plan-and-apply-dev]
     permissions:
       actions: read # Required to download repository artifact.

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -181,6 +181,7 @@ jobs:
   # TODO: How to trigger? PR review, PR comment, deployment status?
   plan-and-apply-prod:
     name: Terraform Deploy Production
+    needs: [plan-and-apply-dev]
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,71 +50,71 @@ resource "aws_route_table_association" "gitops_rta" {
   route_table_id = aws_route_table.gitops_rt.id
 }
 
-resource "aws_security_group" "grafana_sg" {
-  name        = "grafana_sg"
-  description = "Grafana Server security group"
-  vpc_id      = aws_vpc.gitops_vpc.id
-}
+# resource "aws_security_group" "grafana_sg" {
+#   name        = "grafana_sg"
+#   description = "Grafana Server security group"
+#   vpc_id      = aws_vpc.gitops_vpc.id
+# }
 
-resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
-  description       = "Inbound traffic to grafana web interface"
-  security_group_id = aws_security_group.grafana_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 3000
-  ip_protocol       = "tcp"
-  to_port           = 3000
+# resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
+#   description       = "Inbound traffic to grafana web interface"
+#   security_group_id = aws_security_group.grafana_sg.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   from_port         = 3000
+#   ip_protocol       = "tcp"
+#   to_port           = 3000
 
-  tags = {
-    Name = "grafana-ingress-sg-rule-${local.environment}"
-  }
+#   tags = {
+#     Name = "grafana-ingress-sg-rule-${local.environment}"
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
-# trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
-resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
-  description       = "Outbound traffic from grafana server"
-  security_group_id = aws_security_group.grafana_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "-1"
+# # trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
+# resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
+#   description       = "Outbound traffic from grafana server"
+#   security_group_id = aws_security_group.grafana_sg.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   ip_protocol       = "-1"
 
-  tags = {
-    Name = "grafana-egress-sg-rule-${local.environment}"
-  }
+#   tags = {
+#     Name = "grafana-egress-sg-rule-${local.environment}"
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
-data "aws_ami" "ubuntu" {
-  most_recent = true
+# data "aws_ami" "ubuntu" {
+#   most_recent = true
 
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-  }
+#   filter {
+#     name   = "name"
+#     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+#   }
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+#   filter {
+#     name   = "virtualization-type"
+#     values = ["hvm"]
+#   }
 
-  owners = ["099720109477"] # Canonical
-}
+#   owners = ["099720109477"] # Canonical
+# }
 
-# trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
-# trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
-resource "aws_instance" "grafana_server" {
-  ami                    = data.aws_ami.ubuntu.id
-  instance_type          = var.instance_type
-  subnet_id              = aws_subnet.gitops_subnet.id
-  vpc_security_group_ids = [aws_security_group.grafana_sg.id]
-  user_data              = file("userdata.tftpl")
+# # trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
+# # trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
+# resource "aws_instance" "grafana_server" {
+#   ami                    = data.aws_ami.ubuntu.id
+#   instance_type          = var.instance_type
+#   subnet_id              = aws_subnet.gitops_subnet.id
+#   vpc_security_group_ids = [aws_security_group.grafana_sg.id]
+#   user_data              = file("userdata.tftpl")
 
-  tags = {
-    Name = "grafana-server-${local.environment}"
-  }
-}
+#   tags = {
+#     Name = "grafana-server-${local.environment}"
+#   }
+# }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,7 +8,7 @@ output "default_tags" {
   value       = data.aws_default_tags.this.tags
 }
 
-output "grafana_ip" {
-  description = "The connection details of the grafana server."
-  value       = "http://${aws_instance.grafana_server.public_ip}:3000"
-}
+# output "grafana_ip" {
+#   description = "The connection details of the grafana server."
+#   value       = "http://${aws_instance.grafana_server.public_ip}:3000"
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,21 +1,21 @@
-locals {
-  valid_instance_types = ["t2.micro"]
-}
+# locals {
+#   valid_instance_types = ["t2.micro"]
+# }
 
-variable "instance_type" {
-  description = "(Required) Instance type to use. Should be within the free tier"
-  type        = string
+# variable "instance_type" {
+#   description = "(Required) Instance type to use. Should be within the free tier"
+#   type        = string
 
-  validation {
-    condition = contains(local.valid_instance_types, var.instance_type)
-    error_message = format(
-      "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
-      var.instance_type,
-      join(", ", local.valid_instance_types),
-      "Change the instance type variable to one that is permitted."
-    )
-  }
-}
+#   validation {
+#     condition = contains(local.valid_instance_types, var.instance_type)
+#     error_message = format(
+#       "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
+#       var.instance_type,
+#       join(", ", local.valid_instance_types),
+#       "Change the instance type variable to one that is permitted."
+#     )
+#   }
+# }
 
 variable "project_id" {
   description = "(Required) Name of the project"


### PR DESCRIPTION
Reference a reusable workflow for terraform CI to promote changes from _development_ to _production_ environments.

This is achieved using inputs for the deployment environment to use and inputs to govern if changes will be auto applied or not.