### PR TITLE
ci: Add `merge_group` trigger to applicable workflows

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,69 +6,79 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 
 ## Table of contents
 
-- [Requirements](#requirements)
-- [Workflow](#workflow)
-  - [Branching Strategy](#branching-strategy)
-  - [Diagram](#diagram)
-  - [Terraform](#terraform)
+- [More Than Certified GitOps MiniCamp 2024](#more-than-certified-gitops-minicamp-2024)
+  - [Table of contents](#table-of-contents)
+  - [Requirements](#requirements)
+  - [Workflow](#workflow)
+    - [Branching Strategy](#branching-strategy)
+    - [Diagram](#diagram)
+    - [Workflows](#workflows)
+      - [Infracost](#infracost)
 
 ## Requirements
 
-| **Section**             | **Task**                                  | **Self-Reported Status** | **Notes**                                                                                    |
-| ----------------------- | ----------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------- |
-| **Setup**               |                                           |                          |                                                                                              |
-|                         | Main branch is protected                  | :white_check_mark:       |                                                                                              |
-|                         | Cannot merge to main with failed checks   | :white_check_mark:       |                                                                                              |
-|                         | State is stored remotely                  | :white_check_mark:       |                                                                                              |
-|                         | State Locking mechanism is enabled        | :white_check_mark:       |                                                                                              |
-| **Design and Code**     |                                           |                          |                                                                                              |
-|                         | Confirm Account Number                    | :white_check_mark:       | data source post condition                                                                   |
-|                         | Confirm Region                            | :white_check_mark:       | variable validation                                                                          |
-|                         | Add Default Tags                          | :white_check_mark:       | added to provider block                                                                      |
-|                         | Avoid Hardcoded Values                    | :white_check_mark:       |                                                                                              |
-|                         | No plaintext credentials                  | :white_check_mark:       | Environment variables set by OIDC                                                            |
-|                         | Pipeline in GitHub Actions only           | :white_check_mark:       |                                                                                              |
-| **Validate**            |                                           |                          |                                                                                              |
-|                         | terraform fmt pre-commit hook             | :white_check_mark:       | Git Hooks managed by [trunk-io](https://docs.trunk.io/cli/getting-started/actions/git-hooks) |
-|                         | pre-commit hooks are in repo              | :white_check_mark:       |                                                                                              |
-| **Test and Review**     |                                           |                          |                                                                                              |
-|                         | Pipeline works on every PR                | :white_check_mark:       | `on: pull_request trigger`                                                                   |
-|                         | Linter                                    | :white_check_mark:       | TFLint configured with aws plugin and deep check                                             |
-|                         | terraform fmt                             | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/5                                                  |
-|                         | terraform validate                        | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/5                                                  |
-|                         | terraform plan                            | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/5                                                  |
-|                         | Infracost with comment                    | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/4                                                  |
-|                         | Open Policy Agent fail if cost > $10      | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/6                                                  |
-| **Deploy**              |                                           |                          |                                                                                              |
-|                         | terraform apply with human intervention   |                          |                                                                                              |
-|                         | Deploy to production environment          |                          |                                                                                              |
-| **Operate and Monitor** |                                           |                          |                                                                                              |
-|                         | Scheduled drift detection                 |                          |                                                                                              |
-|                         | Scheduled port accessibility check        |                          |                                                                                              |
-| **Readme**              |                                           |                          |                                                                                              |
-|                         | Organized Structure                       |                          |                                                                                              |
-|                         | Explains all workflows                    |                          |                                                                                              |
-|                         | Link to docs for each action              |                          |                                                                                              |
-|                         | Contribution Instructions                 |                          |                                                                                              |
-|                         | Explains merging strategy                 |                          |                                                                                              |
-| **Bonus**               |                                           |                          |                                                                                              |
-|                         | Deploy to multiple environments           |                          |                                                                                              |
-|                         | Ignore non-terraform changes              | :white_check_mark:       | Workflow trigger use paths filter for tf and tfvars files.                                   |
-|                         | Comment PR with useful plan information   | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/7                                                  |
-|                         | Comment PR with useful Linter information | :white_check_mark:       | https://github.com/3ware/gitops-2024/pull/5                                                  |
-|                         | Open an Issue if Drifted                  |                          |                                                                                              |
-|                         | Open an issue if port is inaccessible     |                          |                                                                                              |
-|                         | Comment on PR to apply                    |                          |                                                                                              |
+| **Section**             | **Task**                                  | **Self-Reported Status** | **Notes**                                                  |
+| :---------------------- | :---------------------------------------- | :----------------------: | :--------------------------------------------------------- |
+| ----------------------- | ----------------------------------------- | ------------------------ | ---------------------------------------------------------- |
+| **Setup**               |                                           |                          |                                                            |
+|                         | Main branch is protected                  |    :white_check_mark:    |                                                            |
+|                         | Cannot merge to main with failed checks   |    :white_check_mark:    |                                                            |
+|                         | State is stored remotely                  |    :white_check_mark:    |                                                            |
+|                         | State Locking mechanism is enabled        |    :white_check_mark:    |                                                            |
+| **Design and Code**     |                                           |                          |                                                            |
+|                         | Confirm Account Number                    |    :white_check_mark:    | data source post condition                                 |
+|                         | Confirm Region                            |    :white_check_mark:    | variable validation                                        |
+|                         | Add Default Tags                          |    :white_check_mark:    | added to provider block                                    |
+|                         | Avoid Hardcoded Values                    |    :white_check_mark:    |                                                            |
+|                         | No plaintext credentials                  |    :white_check_mark:    | Environment variables set by OIDC                          |
+|                         | Pipeline in GitHub Actions only           |    :white_check_mark:    |                                                            |
+| **Validate**            |                                           |                          |                                                            |
+|                         | terraform fmt pre-commit hook             |    :white_check_mark:    | Git Hooks managed by trunk-io                              |
+|                         | pre-commit hooks are in repo              |    :white_check_mark:    | Git Hooks managed by trunk-io                              |
+| **Test and Review**     |                                           |                          |                                                            |
+|                         | Pipeline works on every PR                |    :white_check_mark:    | `on: pull_request trigger`                                 |
+|                         | Linter                                    |    :white_check_mark:    | TFLint configured with aws plugin and deep check           |
+|                         | terraform fmt                             |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
+|                         | terraform validate                        |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
+|                         | terraform plan                            |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
+|                         | Infracost with comment                    |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/4                |
+|                         | Open Policy Agent fail if cost > $10      |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/6                |
+| **Deploy**              |                                           |                          |                                                            |
+|                         | terraform apply with human intervention   |                          |                                                            |
+|                         | Deploy to production environment          |                          |                                                            |
+| **Operate and Monitor** |                                           |                          |                                                            |
+|                         | Scheduled drift detection                 |                          |                                                            |
+|                         | Scheduled port accessibility check        |                          |                                                            |
+| **Readme**              |                                           |                          |                                                            |
+|                         | Organized Structure                       |                          |                                                            |
+|                         | Explains all workflows                    |                          |                                                            |
+|                         | Link to docs for each action              |                          |                                                            |
+|                         | Contribution Instructions                 |                          |                                                            |
+|                         | Explains merging strategy                 |                          |                                                            |
+| **Bonus**               |                                           |                          |                                                            |
+|                         | Deploy to multiple environments           |                          |                                                            |
+|                         | Ignore non-terraform changes              |    :white_check_mark:    | Workflow trigger use paths filter for tf and tfvars files. |
+|                         | Comment PR with useful plan information   |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/7                |
+|                         | Comment PR with useful Linter information |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
+|                         | Open an Issue if Drifted                  |                          |                                                            |
+|                         | Open an issue if port is inaccessible     |                          |                                                            |
+|                         | Comment on PR to apply                    |                          |                                                            |
 
 ## Workflow
 
+- Create feature branch off main
+- Commit change locally and push to remote
+- Create a draft pull request that targets the main branch: `gh pr create --draft --base main`
+
+  > [!IMPORTANT]
+  > Pull Request must be set to draft to prevent CODEOWNER reviewers being assigned until the pull request is ready.
+  > This cannot be set by default. See [open discussion](https://github.com/orgs/community/discussions/6943)
+  > Unfortunately this also cannot be automated because action runners, using `GITHUB_TOKEN` for authentication, are unable to run `gh pr ready --undo` as the integration is unavailable. See [open discussion](https://github.com/cli/cli/issues/8910)
+
+- When the [Workflows](#workflows) have completed, mark the PR as ready to assign a reviewer from CODEOWNERS. (again cannot be automated on a runner)
+- If the PR is approved, merge the pull request. The branch will be automatically deleted.
+
 ### Branching Strategy
-
-Create feature branch
-Commit and push changes
-Create a draft pull request - annoying that this cannot be set as the default.
-
-TBC. Currently, feature branch of main.
 
 ```mermaid
 ---
@@ -76,11 +86,15 @@ config:
   theme: base
 ---
 gitGraph
-  commit
-  commit
+  commit id: "prev" tag: "v1.0.0"
   branch feature
-  commit
-  commit
+  switch feature
+  commit id: "Terraform Changes"
+  commit id: "Bug Fix"
+  commit id: "Plan Diff fix"
+  switch main
+  merge feature
+  commit id: "new" tag: "v1.1.0"
 ```
 
 ### Diagram
@@ -133,4 +147,12 @@ flowchart LR
   approve{Approve plan} -->|Yes|P
 ```
 
-### Terraform
+### Workflows
+
+#### Infracost
+
+[Infracost](workflows/infracost.yaml) runs on pull requests when they are opened or synchronized. The workflow generates a cost difference of the resources between the main branch and the proposed changes on the feature branch. The pull request is updated with this information. <!--> # TODO: Add example here
+
+This workflow also flags any policy violations defined in [infracost-policy.rego](../infracost/infracost-policy.rego). See an example in this [pull_request](https://github.com/3ware/gitops-2024/pull/6)
+
+#### Terraform CI

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -7,6 +7,15 @@ on:
 permissions: {}
 
 jobs:
+  convert-to-draft:
+    name: Mark as draft
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as draft
+        uses: voiceflow/draft-pr@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
   validate-pr-title:
     name: Validate PR title
     permissions:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,6 +11,8 @@ jobs:
     name: Mark as draft
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Mark as draft
         uses: voiceflow/draft-pr@latest

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -7,17 +7,6 @@ on:
 permissions: {}
 
 jobs:
-  convert-to-draft:
-    name: Mark as draft
-    if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Mark as draft
-        uses: voiceflow/draft-pr@latest
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
   validate-pr-title:
     name: Validate PR title
     permissions:

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -3,11 +3,13 @@ name: Terraform CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, edited, synchronize]
+    types: [opened, synchronize]
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
       - "**/*.tftpl"
+  merge_group:
+    types: [checks_requested]
 
 # Disable permissions for all available scopes.
 permissions: {}
@@ -23,6 +25,7 @@ defaults:
 
 jobs:
   test-terraform:
+    if: ${{ github.event_name == 'pull_request' }}
     name: Test Terraform
     runs-on: ubuntu-latest
     permissions:
@@ -159,6 +162,7 @@ jobs:
             #### TFLint ${{ steps.tf-validate.outcome }} :white_check_mark:
 
   plan-and-apply-dev:
+    if: ${{ github.event_name == 'pull_request' }}
     name: Terraform Deploy
     needs: [test-terraform]
     permissions:
@@ -178,23 +182,23 @@ jobs:
       provider-credentials: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
       backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
 
-  # TODO: How to trigger? PR review, PR comment, deployment status?
-  plan-and-apply-prod:
-    name: Terraform Deploy
-    needs: [plan-and-apply-dev]
-    permissions:
-      actions: read # Required to download repository artifact.
-      checks: write # Required to add status summary.
-      contents: read # Required to checkout repository.
-      id-token: write # Required to authenticate via OIDC.
-      issues: write # Required to create workflow failure issues.
-      pull-requests: write # Required to add PR comment and label.
-    uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
-    with:
-      environment: production
-      #auto-approve-apply: false
-      #test-destroy: false
-      region: us-east-1
-    secrets:
-      provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
-      backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+  # # TODO: How to trigger? PR review, PR comment, deployment status?
+  # plan-and-apply-prod:
+  #   name: Terraform Deploy
+  #   needs: [plan-and-apply-dev]
+  #   permissions:
+  #     actions: read # Required to download repository artifact.
+  #     checks: write # Required to add status summary.
+  #     contents: read # Required to checkout repository.
+  #     id-token: write # Required to authenticate via OIDC.
+  #     issues: write # Required to create workflow failure issues.
+  #     pull-requests: write # Required to add PR comment and label.
+  #   uses: 3ware/workflows/.github/workflows/terraform-ci.yaml@feat-terraform-ci
+  #   with:
+  #     environment: production
+  #     #auto-approve-apply: false
+  #     #test-destroy: false
+  #     region: us-east-1
+  #   secrets:
+  #     provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
+  #     backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}

--- a/.github/workflows/wait-for-checks.yaml
+++ b/.github/workflows/wait-for-checks.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, edited, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 # Disable permissions for all available scopes
 permissions: {}


### PR DESCRIPTION
Ideally use a merge queue for deployments to production. `merge_group` trigger is required to gather data about required checks.