### PR TITLE
ci(terraform-docs): Add new workflow for terraform documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -21,6 +21,8 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
         - [Plan](#plan)
         - [Apply](#apply)
         - [Diff Check](#diff-check)
+      - [Terraform Docs](#terraform-docs)
+      - [Release](#release)
   - [To do list](#to-do-list)
 
 ## Requirements
@@ -49,11 +51,11 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 | **Test and Review**     |                                           |                          |                                                            |
 |                         | Pipeline works on every PR                |    :white_check_mark:    | `on: pull_request trigger`                                 |
 |                         | Linter                                    |    :white_check_mark:    | TFLint configured with aws plugin and deep check           |
-|                         | terraform fmt                             |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
-|                         | terraform validate                        |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
-|                         | terraform plan                            |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
-|                         | Infracost with comment                    |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/4                |
-|                         | Open Policy Agent fail if cost > $10      |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/6                |
+|                         | terraform fmt                             |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/5         |
+|                         | terraform validate                        |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/5         |
+|                         | terraform plan                            |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/5         |
+|                         | Infracost with comment                    |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/4         |
+|                         | Open Policy Agent fail if cost > $10      |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/6         |
 | **Deploy**              |                                           |                          |                                                            |
 |                         | terraform apply with human intervention   |    :white_check_mark:    |                                                            |
 |                         | Deploy to production environment          |                          | Currently deploying to _development_ environment           |
@@ -69,8 +71,8 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 | **Bonus**               |                                           |                          |                                                            |
 |                         | Deploy to multiple environments           |                          |                                                            |
 |                         | Ignore non-terraform changes              |    :white_check_mark:    | Workflow trigger use paths filter for tf and tfvars files. |
-|                         | Comment PR with useful plan information   |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/7                |
-|                         | Comment PR with useful Linter information |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
+|                         | Comment PR with useful plan information   |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/7         |
+|                         | Comment PR with useful Linter information |    :white_check_mark:    | See PR https://github.com/3ware/gitops-2024/pull/5         |
 |                         | Open an Issue if Drifted                  |                          |                                                            |
 |                         | Open an issue if port is inaccessible     |                          |                                                            |
 |                         | Comment on PR to apply                    |    :white_check_mark:    | PR is approved to apply                                    |
@@ -192,6 +194,7 @@ This workflow also flags any policy violations defined in [infracost-policy.rego
 - Install TFLint using [setup-tflint](https://github.com/terraform-linters/setup-tflint)
 - Initialise TFLint to download the AWS plugin rules
 - Run `tflint`
+- Run [trunk code quality action](https://github.com/marketplace/actions/trunk-check); this runs checkov and trivy security checks
 - Update the PR comments if any of the steps fails and exit the workflow on failure
 
 ##### Plan
@@ -207,9 +210,18 @@ After `terraform plan` has been run, assuming the plan is satisfactory, mark the
 
 Following a successful apply, another plan is run to check for any diffs. If a diff is detected a pull request comment is added and the workflow exits with a failure. If a diff is not detected, the pull request can be merged.
 
+#### Terraform Docs
+
+[Terraform docs](https://github.com/terraform-docs/gh-actions) will run when the pull request is merged. This only needs to run once, following the apply, and not on every commit to a pull request. Updating the README on every commit generates a lot unnecessary commits and you have to pull the updated README prior to the next push to avoid conflicts.
+
+I use my own [Terraform Docs reusable workflow](https://github.com/3ware/workflows/blob/main/.github/workflows/terraform-docs.yaml) which adds job summaries and verified commits.
+
+#### Release
+
+Generate a CHANGELOG and version tag using [semantic release](https://github.com/cycjimmy/semantic-release-action)
+
 ## To do list
 
-- [ ] Terraform Docs
 - [ ] Drift check
 - [ ] Grafana Port Check
 - [ ] Test without setup terraform action because it's already installed on the runner

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,10 +10,18 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
   - [Table of contents](#table-of-contents)
   - [Requirements](#requirements)
   - [Workflow](#workflow)
+    - [When to apply?](#when-to-apply)
+    - [Directories vs Workspaces for multiple environments](#directories-vs-workspaces-for-multiple-environments)
     - [Branching Strategy](#branching-strategy)
     - [Diagram](#diagram)
     - [Workflows](#workflows)
       - [Infracost](#infracost)
+      - [Terraform CI](#terraform-ci)
+        - [Validate](#validate)
+        - [Plan](#plan)
+        - [Apply](#apply)
+        - [Diff Check](#diff-check)
+  - [To do list](#to-do-list)
 
 ## Requirements
 
@@ -47,17 +55,17 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 |                         | Infracost with comment                    |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/4                |
 |                         | Open Policy Agent fail if cost > $10      |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/6                |
 | **Deploy**              |                                           |                          |                                                            |
-|                         | terraform apply with human intervention   |                          |                                                            |
-|                         | Deploy to production environment          |                          |                                                            |
+|                         | terraform apply with human intervention   |    :white_check_mark:    |                                                            |
+|                         | Deploy to production environment          |                          | Currently deploying to _development_ environment           |
 | **Operate and Monitor** |                                           |                          |                                                            |
 |                         | Scheduled drift detection                 |                          |                                                            |
 |                         | Scheduled port accessibility check        |                          |                                                            |
 | **Readme**              |                                           |                          |                                                            |
-|                         | Organized Structure                       |                          |                                                            |
-|                         | Explains all workflows                    |                          |                                                            |
-|                         | Link to docs for each action              |                          |                                                            |
+|                         | Organized Structure                       |    :white_check_mark:    |                                                            |
+|                         | Explains all workflows                    |    :white_check_mark:    |                                                            |
+|                         | Link to docs for each action              |    :white_check_mark:    |                                                            |
 |                         | Contribution Instructions                 |                          |                                                            |
-|                         | Explains merging strategy                 |                          |                                                            |
+|                         | Explains merging strategy                 |    :white_check_mark:    |                                                            |
 | **Bonus**               |                                           |                          |                                                            |
 |                         | Deploy to multiple environments           |                          |                                                            |
 |                         | Ignore non-terraform changes              |    :white_check_mark:    | Workflow trigger use paths filter for tf and tfvars files. |
@@ -65,7 +73,7 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 |                         | Comment PR with useful Linter information |    :white_check_mark:    | https://github.com/3ware/gitops-2024/pull/5                |
 |                         | Open an Issue if Drifted                  |                          |                                                            |
 |                         | Open an issue if port is inaccessible     |                          |                                                            |
-|                         | Comment on PR to apply                    |                          |                                                            |
+|                         | Comment on PR to apply                    |    :white_check_mark:    | PR is approved to apply                                    |
 
 </details>
 
@@ -77,11 +85,23 @@ The main purpose of this mini camp is to build a GitOps pipeline to deploy resou
 
 > [!IMPORTANT]
 > Pull Request must be set to draft to prevent CODEOWNER reviewers being assigned until the pull request is ready.
-> This cannot be set by default. See [open discussion](https://github.com/orgs/community/discussions/6943)
+> This cannot be set by default. See [open discussion](https://github.com/orgs/community/discussions/6943).
 > Unfortunately this also cannot be automated because action runners, using `GITHUB_TOKEN` for authentication, are unable to run `gh pr ready --undo` as the integration is unavailable. See [open discussion](https://github.com/cli/cli/issues/8910)
 
 - When the [Workflows](#workflows) have completed, mark the PR as ready to assign a reviewer from CODEOWNERS. (again cannot be automated on a runner)
-- If the PR is approved, merge the pull request. The branch will be automatically deleted.
+- If the PR is approved, the workflow will run again to apply the changed.
+
+### When to apply?
+
+The [debate rumbles on](https://terramate.io/rethinking-iac/mastering-terraform-workflows-apply-before-merge-vs-apply-after-merge/). In this case, because it's just me, apply before merge is fine.
+
+### Directories vs Workspaces for multiple environments
+
+Another debate. The best argument I have heard for directories was in the Q&A session on 19/10/2024:
+
+> _"anyone should be able to `cd` into a terraform working directory and simply run `terraform plan` without have to worry about workspaces and variable files"_
+
+The workflow currently runs in the _development_ directory, with a view to having a _production_ directory should time allow.
 
 ### Branching Strategy
 
@@ -119,7 +139,7 @@ flowchart LR
   subgraph Pass
     direction LR
     P("`**Met Required Checks**
-    Merge PR & Apply to Prod`")
+    Merge PR`")
   end
   subgraph Test
     direction LR
@@ -136,20 +156,16 @@ flowchart LR
   end
   subgraph Development [Deploy Development Environment]
     direction LR
-    dapply(terraform apply -auto-approve)-->test
-    test("`Test Deployment
-    terraform plan -detailed-exitcode`") -->E{Exit code} -->|2 - Diff|I(Issue)
-    I -->F
+    devplan(terraform plan)-->AP{"`**Approve Plan**
+    via PR approval`"} -->|No|F
+    AP -->|Yes|devapply(terraform apply) -->testdev("`**Diff Check**
+    terraform plan -detailed-exitcode`") -->E{Exit code} -->|2 - Diff|PRC(PR Comment)
   end
-  subgraph Production [Deploy Production Environment]
-    direction LR
-    pplan(terraform plan) -->approve{Approve plan}
-  end
-  PR --> Test
-  validate -->|Pass|dapply
-  E{Exit code} -->|0 - Succeeded|pplan
-  approve{Approve plan} -->|No|F
-  approve{Approve plan} -->|Yes|P
+  PR(Draft Pull Request) --> Test
+  validate -->|Pass|devplan
+  E{Exit code} -->|0 - Succeeded|P
+  PRC -->F
+  F -->|Make changes and resubmit|Test
 ```
 
 ### Workflows
@@ -160,4 +176,44 @@ flowchart LR
 
 This workflow also flags any policy violations defined in [infracost-policy.rego](../infracost/infracost-policy.rego). See an example in this [pull_request](https://github.com/3ware/gitops-2024/pull/6)
 
-#### Terraform CI
+#### Terraform CI
+
+##### Validate
+
+- Setup AWS credentials using [config-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) using OIDC to assume a role and set the authentication parameters as environment variables on the runner. This step is required when TFLint [deep checking](https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/docs/deep_checking.md) for the AWS rule plugin is enabled.
+- Setup terraform using [setup-terraform](https://github.com/hashicorp/setup-terraform)
+
+> [!NOTE]
+> This may not be required because terraform 1.9.7 is installed on the [runner image](https://github.com/actions/runner-images/blob/ubuntu22/20241015.1/images/ubuntu/Ubuntu2204-Readme.md)
+
+- Run `terraform fmt`
+- Run `terraform init`
+- Run `terraform validate`
+- Install TFLint using [setup-tflint](https://github.com/terraform-linters/setup-tflint)
+- Initialise TFLint to download the AWS plugin rules
+- Run `tflint`
+- Update the PR comments if any of the steps fails and exit the workflow on failure
+
+##### Plan
+
+When a draft pull request is opened, and the Test Terraform job has succeeded - a ` terraform plan` will be run.
+The workflow uses [TF-via-PR](https://github.com/DevSecTop/TF-via-PR). This action adds a high level plan and detailed drop down style plan to the workflow summary and updates the pull request with a comment.
+
+##### Apply
+
+After `terraform plan` has been run, assuming the plan is satisfactory, mark the pull request ready for review. Assuming the pull request is approved, the workflow will run again - this time running `terraform apply`, with `plan_parity` set, to ensure the plan has not changed.
+
+##### Diff Check
+
+Following a successful apply, another plan is run to check for any diffs. If a diff is detected a pull request comment is added and the workflow exits with a failure. If a diff is not detected, the pull request can be merged.
+
+## To do list
+
+- [ ] Terraform Docs
+- [ ] Drift check
+- [ ] Grafana Port Check
+- [ ] Test without setup terraform action because it's already installed on the runner
+- [ ] Test plan parity and drift detection
+- [ ] Pull request labels for : approval-required, approved, environment
+- [ ] Job matrix for multiple environments
+- [ ] Conditional execution, if possible and not too complicated, or the plan-and-apply job

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
   workflow_run:
-    workflows: [OpenTofu CI]
+    workflows: [Terraform Docs]
     types: [completed]
     branches: [main]
 

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -21,6 +21,7 @@ concurrency:
 defaults:
   run:
     shell: bash
+    #TODO: Move this to job level if using matrix
     working-directory: ./terraform/development
 
 jobs:
@@ -33,6 +34,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+    #TODO: Use matrix for different environments
     environment: development
 
     steps:
@@ -45,6 +47,7 @@ jobs:
         with:
           aws-region: us-east-1
           mask-aws-account-id: true
+          #TODO: Secrets will need renaming if using matrix for environments. eg AWS_${{ matrix.environment }}_OIDC_ROLE_ARN
           role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
           role-session-name: tflint-deep-check
 
@@ -55,10 +58,10 @@ jobs:
           key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
 
       # Install terraform; required to initialise working directory
+      # TODO: Does this need installing; already installed on runner
       - name: Setup terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          # TODO: Add tfswitch or other to read value from terraform block
           terraform_version: 1.9.7
           terraform_wrapper: true
 
@@ -109,7 +112,6 @@ jobs:
       - name: Install TFLint
         uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
         with:
-          # TODO: Read from somewhere or just use latest
           tflint_version: v0.53.0
           tflint_wrapper: true
 
@@ -167,6 +169,10 @@ jobs:
     # Job is skipped when the pull request is approved, because test does not run
     # TODO: Can this job run: on pr if test succeeds or on pr approve if test is skipped?
     # needs: [test-terraform]
+    # if: |
+    #  always() &&
+    #  github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
+    #  github.event_name ==  github.event.review.state == 'approved' && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,0 +1,22 @@
+name: OpenTofu CI
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - "**/*.tf"
+      - "**/*.tfvars"
+      - "**/*.tftpl"
+
+# Disable permissions for all available scopes
+permissions: {}
+
+jobs:
+  terraform-docs:
+    if: ${{ github.event.pull_request.merged == true }}
+    name: Terraform Docs
+    uses: 3ware/workflows/.github/workflows/terraform-docs.yaml@7880d6b986d1d689f5d219e901b863f1378fea9c # v4.4.0
+    secrets: inherit
+    with:
+      tf-directory: terraform/development

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,4 +1,4 @@
-name: OpenTofu CI
+name: Terraform Docs
 
 on:
   pull_request:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,7 @@ module.exports = {
         "infracost",
         "pr-check",
         "renbot",
+        "release",
         "repo",
         "terraform",
         "terraform-ci",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,6 +19,7 @@ module.exports = {
         "repo",
         "terraform",
         "terraform-ci",
+        "terraform-docs",
         "trunk",
       ],
     ],

--- a/terraform/development/README.md
+++ b/terraform/development/README.md
@@ -1,4 +1,4 @@
-# More Than Certified GitOps 2024 minicamp Terraform documentation
+# More Than Certified GitOps 2024 Minicamp Terraform documentation
 
 <!-- BEGIN_TF_DOCS -->
 


### PR DESCRIPTION
Automate terraform documentation with [terraform docs](https://github.com/terraform-docs/gh-actions)

This action runs when the PR is merged for two reason because it only needs to run once when the code has been successfully deployed.