### PR TITLE
ci(terraform): Improve workflow execution

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -189,7 +189,7 @@ This workflow also flags any policy violations defined in [infracost-policy.rego
 ##### Validate
 
 - Setup AWS credentials using [config-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) using OIDC to assume a role and set the authentication parameters as environment variables on the runner. This step is required when TFLint [deep checking](https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/docs/deep_checking.md) for the AWS rule plugin is enabled.
-- Setup terraform using [setup-terraform](https://github.com/hashicorp/setup-terraform)
+- ~~Setup terraform using [setup-terraform](https://github.com/hashicorp/setup-terraform)~~ Not required. terraform v1.9.7 already installed on runner image.
 
 > [!NOTE]
 > This may not be required because terraform 1.9.7 is installed on the [runner image](https://github.com/actions/runner-images/blob/ubuntu22/20241015.1/images/ubuntu/Ubuntu2204-Readme.md)

--- a/.github/README.md
+++ b/.github/README.md
@@ -208,9 +208,16 @@ This workflow also flags any policy violations defined in [infracost-policy.rego
 When a draft pull request is opened, and the Test Terraform job has succeeded - a ` terraform plan` will be run.
 The workflow uses [TF-via-PR](https://github.com/DevSecTop/TF-via-PR). This action adds a high level plan and detailed drop down style plan to the workflow summary and updates the pull request with a comment.
 
+> [!NOTE]
+> Plan will run on `pull_request` events when the test job is successful.
+
 ##### Apply
 
 After `terraform plan` has been run, assuming the plan is satisfactory, mark the pull request ready for review. Assuming the pull request is approved, the workflow will run again - this time running `terraform apply`, with `plan_parity` set, to ensure the plan has not changed.
+
+> [!NOTE]
+> Apply will run on `pull_request_review` events when the PR is approved and the test workflow is skipped.
+> The test workflow is skipped because it only runs on `pull_request` events. This has been tested in PR https://github.com/3ware/gitops-2024/pull/19
 
 ##### Diff Check
 
@@ -230,8 +237,6 @@ Generate a CHANGELOG and version tag using [semantic release](https://github.com
 
 - [ ] Drift check
 - [ ] Grafana Port Check
-- [ ] Test without setup terraform action because it's already installed on the runner
 - [ ] Test plan parity and drift detection
 - [ ] Pull request labels for : approval-required, approved, environment
-- [ ] Job matrix for multiple environments
-- [ ] Conditional execution, if possible and not too complicated, or the plan-and-apply job
+- [ ] Job matrix / branched for multiple environments

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
   workflow_run:
     workflows: [Terraform Docs]
     types: [completed]
-    branches: [main]
 
 # Disable permissions for all available scopes
 permissions: {}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -158,9 +158,7 @@ jobs:
   plan-and-apply:
     name: Terraform Deploy
     runs-on: ubuntu-latest
-    # Job is skipped when the pull request is approved, because test does not run
-    # TODO: Can this job run: on pr if test succeeds or on pr approve if test is skipped?
-    # needs: [test-terraform]
+    needs: [test-terraform]
     # if: |
     #  always() &&
     #  github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -159,10 +159,10 @@ jobs:
     name: Terraform Deploy
     runs-on: ubuntu-latest
     needs: [test-terraform]
-    # if: |
-    #  always() &&
-    #  github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-    #  github.event_name ==  github.event.review.state == 'approved' && needs.test-terraform.result == 'skipped'
+    if: |
+      always() &&
+      github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
+      github.event.review.state == 'approved' && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -57,14 +57,6 @@ jobs:
           path: .trunk/plugins/
           key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
 
-      # Install terraform; required to initialise working directory
-      # TODO: Does this need installing; already installed on runner
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: 1.9.7
-          terraform_wrapper: true
-
       # Run terraform format
       - name: Terraform fmt
         id: tf-fmt
@@ -199,13 +191,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
           # $REPOSITORY, as described in the github docs, does not work
           role-session-name: gitops2024-development-terraform-deploy
-
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          # TODO: Add tfswitch or other to read value from terraform block
-          terraform_version: 1.9.7
-          terraform_wrapper: true
 
       - name: Terraform
         uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -50,71 +50,71 @@ resource "aws_route_table_association" "gitops_rta" {
   route_table_id = aws_route_table.gitops_rt.id
 }
 
-resource "aws_security_group" "grafana_sg" {
-  name        = "grafana_sg"
-  description = "Grafana Server security group"
-  vpc_id      = aws_vpc.gitops_vpc.id
-}
+# resource "aws_security_group" "grafana_sg" {
+#   name        = "grafana_sg"
+#   description = "Grafana Server security group"
+#   vpc_id      = aws_vpc.gitops_vpc.id
+# }
 
-resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
-  description       = "Inbound traffic to grafana web interface"
-  security_group_id = aws_security_group.grafana_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 3000
-  ip_protocol       = "tcp"
-  to_port           = 3000
+# resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
+#   description       = "Inbound traffic to grafana web interface"
+#   security_group_id = aws_security_group.grafana_sg.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   from_port         = 3000
+#   ip_protocol       = "tcp"
+#   to_port           = 3000
 
-  tags = {
-    Name = "grafana-ingress-sg-rule-${local.environment}"
-  }
+#   tags = {
+#     Name = "grafana-ingress-sg-rule-${local.environment}"
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
-# trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
-resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
-  description       = "Outbound traffic from grafana server"
-  security_group_id = aws_security_group.grafana_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "-1"
+# # trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
+# resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
+#   description       = "Outbound traffic from grafana server"
+#   security_group_id = aws_security_group.grafana_sg.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   ip_protocol       = "-1"
 
-  tags = {
-    Name = "grafana-egress-sg-rule-${local.environment}"
-  }
+#   tags = {
+#     Name = "grafana-egress-sg-rule-${local.environment}"
+#   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
-data "aws_ami" "ubuntu" {
-  most_recent = true
+# data "aws_ami" "ubuntu" {
+#   most_recent = true
 
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-  }
+#   filter {
+#     name   = "name"
+#     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+#   }
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+#   filter {
+#     name   = "virtualization-type"
+#     values = ["hvm"]
+#   }
 
-  owners = ["099720109477"] # Canonical
-}
+#   owners = ["099720109477"] # Canonical
+# }
 
-# trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
-# trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
-resource "aws_instance" "grafana_server" {
-  ami                    = data.aws_ami.ubuntu.id
-  instance_type          = var.instance_type
-  subnet_id              = aws_subnet.gitops_subnet.id
-  vpc_security_group_ids = [aws_security_group.grafana_sg.id]
-  user_data              = file("userdata.tftpl")
+# # trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
+# # trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
+# resource "aws_instance" "grafana_server" {
+#   ami                    = data.aws_ami.ubuntu.id
+#   instance_type          = var.instance_type
+#   subnet_id              = aws_subnet.gitops_subnet.id
+#   vpc_security_group_ids = [aws_security_group.grafana_sg.id]
+#   user_data              = file("userdata.tftpl")
 
-  tags = {
-    Name = "grafana-server-${local.environment}"
-  }
-}
+#   tags = {
+#     Name = "grafana-server-${local.environment}"
+#   }
+# }

--- a/terraform/development/outputs.tf
+++ b/terraform/development/outputs.tf
@@ -9,7 +9,7 @@ output "default_tags" {
   value       = data.aws_default_tags.this.tags
 }
 
-output "grafana_ip" {
-  description = "The connection details of the grafana server."
-  value       = "http://${aws_instance.grafana_server.public_ip}:3000"
-}
+# output "grafana_ip" {
+#   description = "The connection details of the grafana server."
+#   value       = "http://${aws_instance.grafana_server.public_ip}:3000"
+# }

--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -15,19 +15,19 @@ locals {
   }
 }
 
-# data "aws_caller_identity" "current" {
-#   lifecycle {
-#     postcondition {
-#       condition = contains(values(local.valid_account_no), self.id)
-#       error_message = format(
-#         "Invalid AWS account ID specified. Received: '%s', Require: '%s'.\n%s",
-#         self.id,
-#         join(", ", values(local.valid_account_no)),
-#         "Configure AWS credentials to assume the correct role."
-#       )
-#     }
-#   }
-# }
+data "aws_caller_identity" "current" {
+  lifecycle {
+    postcondition {
+      condition = contains(values(local.valid_account_no), self.id)
+      error_message = format(
+        "Invalid AWS account ID specified. Received: '%s', Require: '%s'.\n%s",
+        self.id,
+        join(", ", values(local.valid_account_no)),
+        "Configure AWS credentials to assume the correct role."
+      )
+    }
+  }
+}
 
 locals {
   # Defines a list of permitted environment tag values. Used by the postcondition in the aws_default_tags data source

--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -15,19 +15,19 @@ locals {
   }
 }
 
-data "aws_caller_identity" "current" {
-  lifecycle {
-    postcondition {
-      condition = contains(values(local.valid_account_no), self.id)
-      error_message = format(
-        "Invalid AWS account ID specified. Received: '%s', Require: '%s'.\n%s",
-        self.id,
-        join(", ", values(local.valid_account_no)),
-        "Configure AWS credentials to assume the correct role."
-      )
-    }
-  }
-}
+# data "aws_caller_identity" "current" {
+#   lifecycle {
+#     postcondition {
+#       condition = contains(values(local.valid_account_no), self.id)
+#       error_message = format(
+#         "Invalid AWS account ID specified. Received: '%s', Require: '%s'.\n%s",
+#         self.id,
+#         join(", ", values(local.valid_account_no)),
+#         "Configure AWS credentials to assume the correct role."
+#       )
+#     }
+#   }
+# }
 
 locals {
   # Defines a list of permitted environment tag values. Used by the postcondition in the aws_default_tags data source

--- a/terraform/development/terraform.tfvars
+++ b/terraform/development/terraform.tfvars
@@ -1,4 +1,4 @@
-instance_type     = "t2.micro"
+#instance_type     = "t2.micro"
 project_id        = "gitops-2024"
 region            = "us-east-1"
 subnet_cidr_block = "10.0.2.0/24"

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -1,21 +1,21 @@
-locals {
-  valid_instance_types = ["t2.micro"]
-}
+# locals {
+#   valid_instance_types = ["t2.micro"]
+# }
 
-variable "instance_type" {
-  description = "(Required) Instance type to use. Should be within the free tier"
-  type        = string
+# variable "instance_type" {
+#   description = "(Required) Instance type to use. Should be within the free tier"
+#   type        = string
 
-  validation {
-    condition = contains(local.valid_instance_types, var.instance_type)
-    error_message = format(
-      "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
-      var.instance_type,
-      join(", ", local.valid_instance_types),
-      "Change the instance type variable to one that is permitted."
-    )
-  }
-}
+#   validation {
+#     condition = contains(local.valid_instance_types, var.instance_type)
+#     error_message = format(
+#       "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
+#       var.instance_type,
+#       join(", ", local.valid_instance_types),
+#       "Change the instance type variable to one that is permitted."
+#     )
+#   }
+# }
 
 variable "project_id" {
   description = "(Required) Name of the project"


### PR DESCRIPTION
plan-and-apply execution flow has been improved. `needs: [test-terraform]` has been restored so that plan runs after testing.

To avoid apply being skipped because test-terraform does not run on `pull_request_review`, conditions have been added to allow apply to run even though test is skipped when the PR is approved.
