### PR TITLE
ci(terraform): Change the apply trigger from review to comment

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -8,8 +8,8 @@ on:
       - "**/*.tf"
       - "**/*.tfvars"
       - "**/*.tftpl"
-  pull_request_review:
-    types: [submitted]
+  issue_comment:
+    types: [created, edited]
 
 # Disable permissions for all available scopes.
 permissions: {}
@@ -162,7 +162,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      github.event.review.state == 'approved' && needs.test-terraform.result == 'skipped'
+      github.event.issue.pull_request && contains(github.event.comment.body, 'terraform plan approved') && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.


### PR DESCRIPTION
`pull_request_review` trigger cannot use the paths filter. Therefore the apply workflow could run when a PR is approved that does not contains any terraform file changes.

The trigger has been updated to run apply when a pull request comment with `terraform plan approved` in the body is added.