### PR TITLE
ci(terraform): Test PR comment apply trigger

### DIFF
--- a/.github/workflows/drift-detection.yaml
+++ b/.github/workflows/drift-detection.yaml
@@ -2,7 +2,7 @@ name: Drift Detection
 
 on:
   schedule:
-    - cron: 0 7 * * *
+    - cron: 0 */8 * * 1-5 # Every 8 Hours on weekdays
   workflow_dispatch: {}
 
 permissions: {}
@@ -38,7 +38,7 @@ jobs:
           role-session-name: gitops2024-development-terraform-deploy
 
       - name: Terraform Plan
-        uses: devsectop/tf-via-pr@01cbb55e2c19fee32e9783108c3aafb2baeaedff # v12.0.0-rc-1
+        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
         id: drift-plan
         with:
           working-directory: terraform/development
@@ -51,12 +51,24 @@ jobs:
         uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0
         with:
           token: ${{ github.token }}
-          title: ${{ github.workflow }}
+          title: Configuration ${{ github.workflow }}
           body: |
-            ${{ github.workflow }} workflow run [${{ github.run_id }}](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }}) detected a diff.
 
-            Please check the workflow summary for details.
+            <details><summary>Diff of changes.</summary>
 
-            Add plan highlights to issue when available as outputs from upstream action
+            ```diff
+            ${{ steps.drift-plan.outputs.diff }}
+            ```
+            </details>
+
+            <details><summary>${{ steps.drift-plan.outputs.summary }}</summary>
+
+            ```hcl
+            ${{ steps.drift-plan.outputs.result }}
+            ```
+
+            </details>"
+
+            [View run log.](${{ steps.drift-plan.outputs.run-url }})
 
           labels: tf:diff

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -200,6 +200,13 @@ jobs:
           # $REPOSITORY, as described in the github docs, does not work
           role-session-name: gitops2024-development-terraform-deploy
 
+      - name: Assign approved label
+        if: ${{ env.APPLY_TRIGGER }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Terraform
         uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
         id: terraform
@@ -231,13 +238,6 @@ jobs:
             Add a comment with: **terraform plan approved** to approve.
 
       #TODO: What to do when the plan is rejected
-
-      - name: Assign approved label
-        if: ${{ env.APPLY_TRIGGER }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # This plan should not produce a diff
       - name: Check idempotency

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -8,8 +8,8 @@ on:
       - "**/*.tf"
       - "**/*.tfvars"
       - "**/*.tftpl"
-  pull_request_review:
-    types: [submitted]
+  issue_comment:
+    types: [created, edited]
 
 # Disable permissions for all available scopes.
 permissions: {}
@@ -162,7 +162,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      github.event.review.state == 'approved' && needs.test-terraform.result == 'skipped'
+      github.event.issue.pull_request && contains(github.event.comment.body, 'terraform plan approved') && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -75,6 +75,7 @@ jobs:
         run: terraform validate -no-color
         continue-on-error: true
 
+      # Add PR comment with formatting and validation errors
       - name: Add PR comment on terraform failure
         if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
@@ -95,6 +96,7 @@ jobs:
 
             Resolve these issues and commit your changes to trigger another deployment.
 
+      # Exit this workflow if fmt or validate fail
       - name: Terraform error
         if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
         run: |
@@ -119,6 +121,7 @@ jobs:
           tflint --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
         continue-on-error: true
 
+      # Add PR comment when TFLint detects a violation
       - name: Add PR comment on TFLint failure
         if: ${{ steps.tflint.outputs.exitcode != 0 }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
@@ -135,6 +138,7 @@ jobs:
 
             Resolve these issues and commit your changes to trigger another deployment.
 
+      # Exit workflow if TFLint detects a violation
       - name: TFLint error
         if: ${{ steps.tflint.outputs.exitcode != 0 }}
         run: |
@@ -159,6 +163,9 @@ jobs:
     name: Terraform Deploy
     runs-on: ubuntu-latest
     needs: [test-terraform]
+    # This job should run `terraform plan` following the successful completion of test-terraform
+    # `terraform apply` is triggered when an approval comment is added to the pull request. A pr comment event does not trigger
+    # the test workflow, so `terraform apply` should run when test-terraform is skipped
     if: |
       always() &&
       github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
@@ -172,6 +179,8 @@ jobs:
     environment: development
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+      # Conditions that should evaluated to tru to run terraform apply
+      # Used in `if` conditions to trigger certain steps below or change arguments
       APPLY_TRIGGER: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'terraform plan approved') }}
 
     steps:
@@ -193,8 +202,10 @@ jobs:
 
       - name: Terraform
         uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+        id: terraform
         with:
           working-directory: terraform/development
+          # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
           command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
           arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
           plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
@@ -208,19 +219,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add PR comment to request plan approval
+      - name: Update PR comment to request plan approval
         if: ${{ github.event_name == 'pull_request' }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: approve-plan
-          hide_and_recreate: true
-          hide_classify: RESOLVED
+          header: ${{ steps.terraform.outputs.comment-id }}
+          append: true
           message: |
-            #### Plan Approval required.
+            #### Terraform Plan Approval required.
 
             Add a comment with: **terraform plan approved** to approve.
-
-            Reject the plan with: **terraform plan rejected**
 
       #TODO: What to do when the plan is rejected
 

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -199,6 +199,21 @@ jobs:
           arg_lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
           plan_parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
 
+      - name: Assign approval label
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assign approved label
+        run: >
+          ${{ env.APPLY_TRIGGER }} &&
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required" ||
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approval rejected" --remove-label "approval required" }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # This plan should not produce a diff
       - name: Check idempotency
         if: ${{ env.APPLY_TRIGGER }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -207,10 +207,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Assign approved label
-        run: >
-          ${{ env.APPLY_TRIGGER }} &&
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required" ||
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "approval rejected" --remove-label "approval required" }}
+        if: ${{ github.event_name == 'issue_comment' }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -192,12 +192,14 @@ jobs:
           role-session-name: gitops2024-development-terraform-deploy
 
       - name: Terraform
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
+        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
         with:
-          arg_chdir: terraform/development
-          arg_command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
-          arg_lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-          plan_parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+          working-directory: terraform/development
+          command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
+          arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+          plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+          hide-args: true
+          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Assign approval label
         if: ${{ github.event_name == 'pull_request' }}
@@ -217,16 +219,19 @@ jobs:
       - name: Check idempotency
         if: ${{ env.APPLY_TRIGGER }}
         id: idempotency
-        uses: devsectop/tf-via-pr@cc83c7bae8216e747bb8c074524665b2416822f5 # v11.4.6
+        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
         with:
-          arg_chdir: terraform/development
-          arg_command: plan
-          arg_lock: false
-          arg_detailed_exitcode: true
-          arg_out: tfplan-${{ github.head_ref}}-PR${{ github.event.pull_request.number}}-check # Give this plan a different name
+          working-directory: terraform/development
+          command: plan
+          arg-lock: false
+          # TODO: Removed from current version.
+          #? How will we do a test destroy in dev without a diff plan which doesn't overwrite the main plan
+          #arg-out: tfplan-${{ github.head_ref}}-PR${{ github.event.pull_request.number}}-check # Give this plan a different name
+          hide-args: true
+          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Add PR comment terraform diff
-        if: ${{ steps.idempotency.outputs.exitcode != 0 }}
+        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: Diff Error
@@ -238,6 +243,6 @@ jobs:
             ${{ github.workflow }} workflow run: [${{ github.run_id }}](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
       - name: Diff Error
-        if: ${{ steps.idempotency.outputs.exitcode != 0 }}
+        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
         run: |
           exit 1

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           header: TLint error
           hide_and_recreate: true
-          hide_classify: OUTDATED
+          hide_classify: RESOLVED
           message: |
             #### TFLint failure :x:
 
@@ -208,8 +208,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Add PR comment to request plan approval
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: approve-plan
+          hide_and_recreate: true
+          hide_classify: RESOLVED
+          message: |
+            #### Plan Approval required.
+
+            Add a comment with: **terraform plan approved** to approve.
+
+            Reject the plan with: **terraform plan rejected**
+
+      #TODO: What to do when the plan is rejected
+
       - name: Assign approved label
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: ${{ env.APPLY_TRIGGER }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label "approved" --remove-label "approval required"
         env:

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -50,71 +50,71 @@ resource "aws_route_table_association" "gitops_rta" {
   route_table_id = aws_route_table.gitops_rt.id
 }
 
-# resource "aws_security_group" "grafana_sg" {
-#   name        = "grafana_sg"
-#   description = "Grafana Server security group"
-#   vpc_id      = aws_vpc.gitops_vpc.id
-# }
+resource "aws_security_group" "grafana_sg" {
+  name        = "grafana_sg"
+  description = "Grafana Server security group"
+  vpc_id      = aws_vpc.gitops_vpc.id
+}
 
-# resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
-#   description       = "Inbound traffic to grafana web interface"
-#   security_group_id = aws_security_group.grafana_sg.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   from_port         = 3000
-#   ip_protocol       = "tcp"
-#   to_port           = 3000
+resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
+  description       = "Inbound traffic to grafana web interface"
+  security_group_id = aws_security_group.grafana_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 3000
+  ip_protocol       = "tcp"
+  to_port           = 3000
 
-#   tags = {
-#     Name = "grafana-ingress-sg-rule-${local.environment}"
-#   }
+  tags = {
+    Name = "grafana-ingress-sg-rule-${local.environment}"
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# # trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
-# resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
-#   description       = "Outbound traffic from grafana server"
-#   security_group_id = aws_security_group.grafana_sg.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   ip_protocol       = "-1"
+# trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
+resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
+  description       = "Outbound traffic from grafana server"
+  security_group_id = aws_security_group.grafana_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
 
-#   tags = {
-#     Name = "grafana-egress-sg-rule-${local.environment}"
-#   }
+  tags = {
+    Name = "grafana-egress-sg-rule-${local.environment}"
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# data "aws_ami" "ubuntu" {
-#   most_recent = true
+data "aws_ami" "ubuntu" {
+  most_recent = true
 
-#   filter {
-#     name   = "name"
-#     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-#   }
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
 
-#   filter {
-#     name   = "virtualization-type"
-#     values = ["hvm"]
-#   }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 
-#   owners = ["099720109477"] # Canonical
-# }
+  owners = ["099720109477"] # Canonical
+}
 
-# # trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
-# # trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
-# resource "aws_instance" "grafana_server" {
-#   ami                    = data.aws_ami.ubuntu.id
-#   instance_type          = var.instance_type
-#   subnet_id              = aws_subnet.gitops_subnet.id
-#   vpc_security_group_ids = [aws_security_group.grafana_sg.id]
-#   user_data              = file("userdata.tftpl")
+# trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
+# trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
+resource "aws_instance" "grafana_server" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.gitops_subnet.id
+  vpc_security_group_ids = [aws_security_group.grafana_sg.id]
+  user_data              = file("userdata.tftpl")
 
-#   tags = {
-#     Name = "grafana-server-${local.environment}"
-#   }
-# }
+  tags = {
+    Name = "grafana-server-${local.environment}"
+  }
+}

--- a/terraform/development/outputs.tf
+++ b/terraform/development/outputs.tf
@@ -9,7 +9,7 @@ output "default_tags" {
   value       = data.aws_default_tags.this.tags
 }
 
-# output "grafana_ip" {
-#   description = "The connection details of the grafana server."
-#   value       = "http://${aws_instance.grafana_server.public_ip}:3000"
-# }
+output "grafana_ip" {
+  description = "The connection details of the grafana server."
+  value       = "http://${aws_instance.grafana_server.public_ip}:3000"
+}

--- a/terraform/development/terraform.tfvars
+++ b/terraform/development/terraform.tfvars
@@ -1,4 +1,4 @@
-#instance_type     = "t2.micro"
+instance_type     = "t2.micro"
 project_id        = "gitops-2024"
 region            = "us-east-1"
 subnet_cidr_block = "10.0.2.0/24"

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -1,21 +1,21 @@
-# locals {
-#   valid_instance_types = ["t2.micro"]
-# }
+locals {
+  valid_instance_types = ["t2.micro"]
+}
 
-# variable "instance_type" {
-#   description = "(Required) Instance type to use. Should be within the free tier"
-#   type        = string
+variable "instance_type" {
+  description = "(Required) Instance type to use. Should be within the free tier"
+  type        = string
 
-#   validation {
-#     condition = contains(local.valid_instance_types, var.instance_type)
-#     error_message = format(
-#       "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
-#       var.instance_type,
-#       join(", ", local.valid_instance_types),
-#       "Change the instance type variable to one that is permitted."
-#     )
-#   }
-# }
+  validation {
+    condition = contains(local.valid_instance_types, var.instance_type)
+    error_message = format(
+      "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
+      var.instance_type,
+      join(", ", local.valid_instance_types),
+      "Change the instance type variable to one that is permitted."
+    )
+  }
+}
 
 variable "project_id" {
   description = "(Required) Name of the project"


### PR DESCRIPTION
Replace draft PR approval triggering apply with adding a PR comment with the text: "terraform plan approved". Not all pull requests will relate to terraform and, because the `pull_request_review` trigger does not support the paths filter, pull request approval could trigger a terraform apply with the previous trigger.