### PR TITLE
ci(terraform): Change apply trigger to `pull_request.labeled`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -166,7 +166,7 @@ flowchart LR
   subgraph Development [Deploy Development Environment]
     direction LR
     devplan(terraform plan)-->AP{"`**Approve Plan**
-    via PR comment`"} -->|No|F
+    via 'approved` label"} -->|No|F
     AP -->|Yes|devapply(terraform apply) -->testdev("`**Diff Check**
     terraform plan -detailed-exitcode`") -->E{Exit code} -->|2 - Diff|PRC(PR Comment)
   end
@@ -210,10 +210,14 @@ The workflow uses [TF-via-PR](https://github.com/DevSecTop/TF-via-PR). This acti
 
 ##### Apply
 
-After `terraform plan` has been run, assuming the plan is satisfactory, comment on the pull request to approve the plan. The workflow will run again - this time running `terraform apply`, with `plan_parity` set, to ensure the plan has not changed.
+After `terraform plan` has been run, assuming the plan is satisfactory, add the 'approved' label to he pull request to approve the plan. The workflow will run again - this time running `terraform apply`, with `plan_parity` set, to ensure the plan has not changed.
+
+I tried using `pull_request_review` as the apply trigger, but this trigger does not support the paths filter which means an apply could be triggered when adding `.yaml` files - not ideal. See (https://github.com/3ware/gitops-2024/pull/22).
+
+I also tried using `issue_comment` but, because this runs on the default branch, a diff was always detected between `plan` and `apply` - not ideal. See (https://github.com/3ware/gitops-2024/pull/29)
 
 > [!NOTE]
-> Apply will run when the pull request comment body contains: **terraform plan approved** and the test workflow is skipped.
+> Apply will run when the 'approved' label is added and the test workflow is skipped.
 > The test workflow is skipped because it only runs on `pull_request` events. This has been tested in PR https://github.com/3ware/gitops-2024/pull/19
 
 ##### Diff Check
@@ -236,4 +240,3 @@ Generate a CHANGELOG and version tag using [semantic release](https://github.com
 - [ ] Pull request labels environment
 - [ ] Job matrix / branched for multiple environments
 - [ ] Replace manual terraform commands with tf-via-pr for fmt and validate now this is supported
-- [ ] `plan-parity` seems a bit flaky. Need to test properly and log issue if required

--- a/.github/README.md
+++ b/.github/README.md
@@ -235,5 +235,5 @@ Generate a CHANGELOG and version tag using [semantic release](https://github.com
 - [ ] Grafana Port Check
 - [ ] Pull request labels environment
 - [ ] Job matrix / branched for multiple environments
-- [ ] Update plan comment with approval text as opposed to new comment
 - [ ] Replace manual terraform commands with tf-via-pr for fmt and validate now this is supported
+- [ ] `plan-parity` seems a bit flaky. Need to test properly and log issue if required

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   test-terraform:
-    if: ${{ !contains(github.event.pull_request.labels.*.name , 'approved') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
     name: Test Terraform
     runs-on: ubuntu-latest
     permissions:
@@ -157,121 +157,121 @@ jobs:
             #### Terraform Validation ${{ steps.tf-validate.outcome }} :white_check_mark:
             #### TFLint ${{ steps.tf-validate.outcome }} :white_check_mark:
 
-  plan-and-apply:
-    name: Terraform Deploy
-    runs-on: ubuntu-latest
-    needs: [test-terraform]
-    # This job should run `terraform plan` following the successful completion of test-terraform
-    # `terraform apply` is triggered when the 'approved' label is added to the pull request. A pr comment event does not trigger
-    # the test workflow, so `terraform apply` should run when test-terraform is skipped
-    if: |
-      always() &&
-      github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      contains(github.event.pull_request.labels.name, 'approved') && needs.test-terraform.result == 'skipped'
-    permissions:
-      actions: read # Required to download repository artifact.
-      checks: write # Required to add status summary.
-      contents: read # Required to checkout repository.
-      id-token: write # Required to authenticate via OIDC.
-      pull-requests: write # Required to add PR comment and label.
-    environment: development
-    env:
-      TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      # Run plan steps if the pull request does not have the 'approved' label
-      PLAN_TRIGGER: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
-      # Run apply steps if the pull request does not have the 'approved' label
-      APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
+  # plan-and-apply:
+  #   name: Terraform Deploy
+  #   runs-on: ubuntu-latest
+  #   needs: [test-terraform]
+  #   # This job should run `terraform plan` following the successful completion of test-terraform
+  #   # `terraform apply` is triggered when the 'approved' label is added to the pull request. A pr comment event does not trigger
+  #   # the test workflow, so `terraform apply` should run when test-terraform is skipped
+  #   if: |
+  #     always() &&
+  #     github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
+  #     contains(github.event.pull_request.labels.name, 'approved') && needs.test-terraform.result == 'skipped'
+  #   permissions:
+  #     actions: read # Required to download repository artifact.
+  #     checks: write # Required to add status summary.
+  #     contents: read # Required to checkout repository.
+  #     id-token: write # Required to authenticate via OIDC.
+  #     pull-requests: write # Required to add PR comment and label.
+  #   environment: development
+  #   env:
+  #     TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+  #     # Run plan steps if the pull request does not have the 'approved' label
+  #     PLAN_TRIGGER: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
+  #     # Run apply steps if the pull request does have the 'approved' label
+  #     APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
 
-    steps:
-      # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
-      # Because the workflow is running in the issue_comment context the PR checks are not updated
-      - name: Update PR comment to request plan approval
-        if: ${{ env.APPLY_TRIGGER }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: tf-approval
-          recreate: true
-          message: |
-            #### Terraform Plan Approved.
+  #   steps:
+  #     # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
+  #     # Because the workflow is running in the issue_comment context the PR checks are not updated
+  #     - name: Update PR comment to request plan approval
+  #       if: ${{ env.APPLY_TRIGGER }}
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: tf-approval
+  #         recreate: true
+  #         message: |
+  #           #### Terraform Plan Approved.
 
-            Apply workflow is running. [View output](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+  #           Apply workflow is running. [View output](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
-            > [!CAUTION]
-            > Do not merge the pull request until the apply workflow has completed.
+  #           > [!CAUTION]
+  #           > Do not merge the pull request until the apply workflow has completed.
 
-      # - name: Set environment variables
-      #   # Replace '/' with '-' Most things like dashes and do not like forward slashes
-      #   run: |
-      #     echo "REPOSITORY=$(echo ${{ github.repository }} | tr / -)" >> "$GITHUB_ENV"
+  #     # - name: Set environment variables
+  #     #   # Replace '/' with '-' Most things like dashes and do not like forward slashes
+  #     #   run: |
+  #     #     echo "REPOSITORY=$(echo ${{ github.repository }} | tr / -)" >> "$GITHUB_ENV"
 
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+  #     - name: Checkout repository
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
-          # $REPOSITORY, as described in the github docs, does not work
-          role-session-name: gitops2024-development-terraform-deploy
+  #     - name: Configure AWS credentials via OIDC
+  #       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+  #       with:
+  #         aws-region: us-east-1
+  #         role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+  #         # $REPOSITORY, as described in the github docs, does not work
+  #         role-session-name: gitops2024-development-terraform-deploy
 
-      - name: Terraform
-        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-        id: terraform
-        with:
-          working-directory: terraform/development
-          # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
-          command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
-          arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-          plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-          hide-args: true
-          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+  #     - name: Terraform
+  #       uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+  #       id: terraform
+  #       with:
+  #         working-directory: terraform/development
+  #         # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
+  #         command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
+  #         arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+  #         plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+  #         hide-args: true
+  #         plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-      - name: Assign approval label
-        if: ${{ env.PLAN_TRIGGER }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Assign approval label
+  #       if: ${{ env.PLAN_TRIGGER }}
+  #       run: |
+  #         gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update PR comment to request plan approval
-        if: ${{ env.PLAN_TRIGGER }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: tf-approval
-          message: |
-            #### Terraform Plan Approval required.
+  #     - name: Update PR comment to request plan approval
+  #       if: ${{ env.PLAN_TRIGGER }}
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: tf-approval
+  #         message: |
+  #           #### Terraform Plan Approval required.
 
-            Add the 'approved' label to apply the planned changes.
+  #           Add the 'approved' label to apply the planned changes.
 
-      #TODO: What to do when the plan is rejected
+  #     #TODO: What to do when the plan is rejected
 
-      # This plan should not produce a diff
-      - name: Check idempotency
-        if: ${{ env.APPLY_TRIGGER }}
-        id: idempotency
-        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-        with:
-          working-directory: terraform/development
-          command: plan
-          arg-lock: false
-          hide-args: true
-          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+  #     # This plan should not produce a diff
+  #     - name: Check idempotency
+  #       if: ${{ env.APPLY_TRIGGER }}
+  #       id: idempotency
+  #       uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+  #       with:
+  #         working-directory: terraform/development
+  #         command: plan
+  #         arg-lock: false
+  #         hide-args: true
+  #         plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-      - name: Add PR comment terraform diff
-        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: Diff Error
-          message: |
-            > [!WARNING]
-            > ${{ github.workflow }} detected a diff after a successful `terraform apply`
+  #     - name: Add PR comment terraform diff
+  #       if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: Diff Error
+  #         message: |
+  #           > [!WARNING]
+  #           > ${{ github.workflow }} detected a diff after a successful `terraform apply`
 
-            Please resolve the error and commit your changes to re-run the workflow.
+  #           Please resolve the error and commit your changes to re-run the workflow.
 
-            [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+  #           [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
-      - name: Diff Error
-        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-        run: |
-          exit 1
+  #     - name: Diff Error
+  #       if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+  #       run: |
+  #         exit 1

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -187,7 +187,7 @@ jobs:
       # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
       # Because the workflow is running in the issue_comment context the PR checks are not updated
       - name: Update PR comment to request plan approval
-        if: ${{ env.APPLY_TRIGGER }}
+        if: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: tf-approval

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -208,6 +208,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Remove approval label
+        if: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "approval required"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
@@ -224,7 +231,7 @@ jobs:
           # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
           command: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'apply' || 'plan' }}
           arg-lock: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
-          plan-parity: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
+          # plan-parity: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
           hide-args: true
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -3,13 +3,11 @@ name: Terraform CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
+    types: [opened, labeled, synchronize]
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
       - "**/*.tftpl"
-  issue_comment:
-    types: [created, edited]
 
 # Disable permissions for all available scopes.
 permissions: {}
@@ -26,7 +24,7 @@ defaults:
 
 jobs:
   test-terraform:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event.label.name != 'approved' }}
     name: Test Terraform
     runs-on: ubuntu-latest
     permissions:
@@ -164,12 +162,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-terraform]
     # This job should run `terraform plan` following the successful completion of test-terraform
-    # `terraform apply` is triggered when an approval comment is added to the pull request. A pr comment event does not trigger
+    # `terraform apply` is triggered when the 'approved' label is added to the pull request. A pr comment event does not trigger
     # the test workflow, so `terraform apply` should run when test-terraform is skipped
     if: |
       always() &&
       github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      github.event.issue.pull_request && contains(github.event.comment.body, 'terraform plan approved') && needs.test-terraform.result == 'skipped'
+      github.event.label.name == 'approved' && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.
@@ -181,7 +179,7 @@ jobs:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       # Conditions that should evaluated to tru to run terraform apply
       # Used in `if` conditions to trigger certain steps below or change arguments
-      APPLY_TRIGGER: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'terraform plan approved') }}
+      APPLY_TRIGGER: ${{ github.event.label.name == 'approved' }}
 
     steps:
       # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
@@ -190,14 +188,14 @@ jobs:
         if: ${{ env.APPLY_TRIGGER }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: tf-approved
-          number: ${{ github.event.issue.number }}
+          header: tf-approval
+          recreate: true
           message: |
             #### Terraform Plan Approved.
 
             Apply workflow is running. [View output](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
-            > [!WARNING]
+            > [!CAUTION]
             > Do not merge the pull request until the apply workflow has completed.
 
       # - name: Set environment variables
@@ -207,13 +205,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Assign approved label
-        if: ${{ env.APPLY_TRIGGER }}
-        run: |
-          gh pr edit ${{ github.event.issue.number }} --add-label "approved" --remove-label "approval required"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
@@ -231,26 +222,26 @@ jobs:
           # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
           command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
           arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-          #plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+          plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
           hide-args: true
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Assign approval label
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event.label.name != 'approved' }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR comment to request plan approval
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event.label.name != 'approved' }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: tf-approval
           message: |
             #### Terraform Plan Approval required.
 
-            Add a comment with: **terraform plan approved** to approve.
+            Add the 'approved' label to apply the planned changes.
 
       #TODO: What to do when the plan is rejected
 
@@ -263,9 +254,6 @@ jobs:
           working-directory: terraform/development
           command: plan
           arg-lock: false
-          # TODO: Removed from current version.
-          #? How will we do a test destroy in dev without a diff plan which doesn't overwrite the main plan
-          #arg-out: tfplan-${{ github.head_ref}}-PR${{ github.event.pull_request.number}}-check # Give this plan a different name
           hide-args: true
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
@@ -275,11 +263,12 @@ jobs:
         with:
           header: Diff Error
           message: |
-            ####  ${{ github.workflow }} detected a diff during deployment to the development environment
+            > [!WARNING]
+            > ${{ github.workflow }} detected a diff after a successful `terraform apply`
 
             Please resolve the error and commit your changes to re-run the workflow.
 
-            ${{ github.workflow }} workflow run: [${{ github.run_id }}](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+            [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
       - name: Diff Error
         if: ${{ steps.idempotency.outputs.exitcode == 2 }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -3,7 +3,7 @@ name: Terraform CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, labeled, synchronize]
+    types: [opened, labeled, synchronize, unlabeled]
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
@@ -158,121 +158,127 @@ jobs:
             #### Terraform Validation ${{ steps.tf-validate.outcome }} :white_check_mark:
             #### TFLint ${{ steps.tf-validate.outcome }} :white_check_mark:
 
-  # plan-and-apply:
-  #   name: Terraform Deploy
-  #   runs-on: ubuntu-latest
-  #   needs: [test-terraform]
-  #   # This job should run `terraform plan` following the successful completion of test-terraform
-  #   # `terraform apply` is triggered when the 'approved' label is added to the pull request. A pr comment event does not trigger
-  #   # the test workflow, so `terraform apply` should run when test-terraform is skipped
-  #   if: |
-  #     always() &&
-  #     github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-  #     contains(github.event.pull_request.labels.name, 'approved') && needs.test-terraform.result == 'skipped'
-  #   permissions:
-  #     actions: read # Required to download repository artifact.
-  #     checks: write # Required to add status summary.
-  #     contents: read # Required to checkout repository.
-  #     id-token: write # Required to authenticate via OIDC.
-  #     pull-requests: write # Required to add PR comment and label.
-  #   environment: development
-  #   env:
-  #     TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-  #     # Run plan steps if the pull request does not have the 'approved' label
-  #     PLAN_TRIGGER: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
-  #     # Run apply steps if the pull request does have the 'approved' label
-  #     APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
+  plan-and-apply:
+    name: Terraform Deploy
+    runs-on: ubuntu-latest
+    needs: [test-terraform]
+    # This job should run `terraform plan` following the successful completion of test-terraform
+    # `terraform apply` is triggered when the 'approved' label is added to the pull request. An 'approved' label does not trigger
+    # the test workflow, so `terraform apply` should run when test-terraform is skipped
+    if: |
+      always() &&
+      github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
+      github.event.label.name =='approved' && needs.test-terraform.result == 'skipped'
+    permissions:
+      actions: read # Required to download repository artifact.
+      checks: write # Required to add status summary.
+      contents: read # Required to checkout repository.
+      id-token: write # Required to authenticate via OIDC.
+      pull-requests: write # Required to add PR comment and label.
+    environment: development
+    env:
+      TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+      # Run plan steps if the pull request does not have the 'approved' label
+      PLAN_TRIGGER: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
+      # Run apply steps if the pull request does have the 'approved' label
+      APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
 
-  #   steps:
-  #     # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
-  #     # Because the workflow is running in the issue_comment context the PR checks are not updated
-  #     - name: Update PR comment to request plan approval
-  #       if: ${{ env.APPLY_TRIGGER }}
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: tf-approval
-  #         recreate: true
-  #         message: |
-  #           #### Terraform Plan Approved.
+    steps:
+      # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
+      # Because the workflow is running in the issue_comment context the PR checks are not updated
+      - name: Update PR comment to request plan approval
+        if: ${{ env.APPLY_TRIGGER }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: tf-approval
+          recreate: true
+          message: |
+            #### Terraform Plan Approved.
 
-  #           Apply workflow is running. [View output](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+            Apply workflow is running. [View output](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
-  #           > [!CAUTION]
-  #           > Do not merge the pull request until the apply workflow has completed.
+            > [!CAUTION]
+            > Do not merge the pull request until the apply workflow has completed.
 
-  #     # - name: Set environment variables
-  #     #   # Replace '/' with '-' Most things like dashes and do not like forward slashes
-  #     #   run: |
-  #     #     echo "REPOSITORY=$(echo ${{ github.repository }} | tr / -)" >> "$GITHUB_ENV"
+      # - name: Set environment variables
+      #   # Replace '/' with '-' Most things like dashes and do not like forward slashes
+      #   run: |
+      #     echo "REPOSITORY=$(echo ${{ github.repository }} | tr / -)" >> "$GITHUB_ENV"
 
-  #     - name: Checkout repository
-  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-  #     - name: Configure AWS credentials via OIDC
-  #       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-  #       with:
-  #         aws-region: us-east-1
-  #         role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
-  #         # $REPOSITORY, as described in the github docs, does not work
-  #         role-session-name: gitops2024-development-terraform-deploy
+      - name: label
+        run: |
+          echo ${{ env.PLAN_TRIGGER }}
+          echo
+          echo ${{ env.APPLY_TRIGGER }}
 
-  #     - name: Terraform
-  #       uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-  #       id: terraform
-  #       with:
-  #         working-directory: terraform/development
-  #         # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
-  #         command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
-  #         arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-  #         plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-  #         hide-args: true
-  #         plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+      # - name: Configure AWS credentials via OIDC
+      #   uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      #   with:
+      #     aws-region: us-east-1
+      #     role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+      #     # $REPOSITORY, as described in the github docs, does not work
+      #     role-session-name: gitops2024-development-terraform-deploy
 
-  #     - name: Assign approval label
-  #       if: ${{ env.PLAN_TRIGGER }}
-  #       run: |
-  #         gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Terraform
+      #   uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+      #   id: terraform
+      #   with:
+      #     working-directory: terraform/development
+      #     # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
+      #     command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
+      #     arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+      #     plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
+      #     hide-args: true
+      #     plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-  #     - name: Update PR comment to request plan approval
-  #       if: ${{ env.PLAN_TRIGGER }}
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: tf-approval
-  #         message: |
-  #           #### Terraform Plan Approval required.
+      # - name: Assign approval label
+      #   if: ${{ env.PLAN_TRIGGER }}
+      #   run: |
+      #     gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #           Add the 'approved' label to apply the planned changes.
+      # - name: Update PR comment to request plan approval
+      #   if: ${{ env.PLAN_TRIGGER }}
+      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+      #   with:
+      #     header: tf-approval
+      #     message: |
+      #       #### Terraform Plan Approval required.
 
-  #     #TODO: What to do when the plan is rejected
+      #       Add the 'approved' label to apply the planned changes.
 
-  #     # This plan should not produce a diff
-  #     - name: Check idempotency
-  #       if: ${{ env.APPLY_TRIGGER }}
-  #       id: idempotency
-  #       uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-  #       with:
-  #         working-directory: terraform/development
-  #         command: plan
-  #         arg-lock: false
-  #         hide-args: true
-  #         plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+      # #TODO: What to do when the plan is rejected
 
-  #     - name: Add PR comment terraform diff
-  #       if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: Diff Error
-  #         message: |
-  #           > [!WARNING]
-  #           > ${{ github.workflow }} detected a diff after a successful `terraform apply`
+      # # This plan should not produce a diff
+      # - name: Check idempotency
+      #   if: ${{ env.APPLY_TRIGGER }}
+      #   id: idempotency
+      #   uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+      #   with:
+      #     working-directory: terraform/development
+      #     command: plan
+      #     arg-lock: false
+      #     hide-args: true
+      #     plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-  #           Please resolve the error and commit your changes to re-run the workflow.
+      # - name: Add PR comment terraform diff
+      #   if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+      #   with:
+      #     header: Diff Error
+      #     message: |
+      #       > [!WARNING]
+      #       > ${{ github.workflow }} detected a diff after a successful `terraform apply`
 
-  #           [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+      #       Please resolve the error and commit your changes to re-run the workflow.
 
-  #     - name: Diff Error
-  #       if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-  #       run: |
-  #         exit 1
+      #       [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+
+      # - name: Diff Error
+      #   if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+      #   run: |
+      #     exit 1

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -293,7 +293,7 @@ jobs:
           exit 1
 
       - name: Update status comment
-        if: ${{ steps.idempotency.outputs.exitcode == 0 }}
+        if: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && steps.idempotency.outputs.exitcode == 0 }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: status

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -24,6 +24,7 @@ defaults:
 
 jobs:
   test-terraform:
+    # Do not run the test workflow if the 'approved' label is applied
     if: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
     name: Test Terraform
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -178,7 +178,7 @@ jobs:
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       # Run plan steps if the pull request does not have the 'approved' label
-      PLAN_TRIGGER: ${{ !contains(github.event.pull_request.labels.*.name , 'approved') }}
+      PLAN_TRIGGER: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
       # Run apply steps if the pull request does not have the 'approved' label
       APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
 

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -3,7 +3,7 @@ name: Terraform CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, labeled, synchronize, unlabeled]
+    types: [opened, labeled, synchronize]
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
@@ -208,77 +208,71 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: label
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+          # $REPOSITORY, as described in the github docs, does not work
+          role-session-name: gitops2024-development-terraform-deploy
+
+      - name: Terraform
+        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+        id: terraform
+        with:
+          working-directory: terraform/development
+          # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
+          command: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'apply' || 'plan' }}
+          arg-lock: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
+          plan-parity: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
+          hide-args: true
+          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+
+      - name: Assign approval label
+        if: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
         run: |
-          echo ${{ env.PLAN_TRIGGER }}
-          echo
-          echo ${{ env.APPLY_TRIGGER }}
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Configure AWS credentials via OIDC
-      #   uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-      #   with:
-      #     aws-region: us-east-1
-      #     role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
-      #     # $REPOSITORY, as described in the github docs, does not work
-      #     role-session-name: gitops2024-development-terraform-deploy
+      - name: Update PR comment to request plan approval
+        if: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: tf-approval
+          message: |
+            #### Terraform Plan Approval required.
 
-      # - name: Terraform
-      #   uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-      #   id: terraform
-      #   with:
-      #     working-directory: terraform/development
-      #     # If the APPLY_TRIGGER is true, run 'apply'; if not, run 'plan'
-      #     command: ${{ env.APPLY_TRIGGER && 'apply' || 'plan' }}
-      #     arg-lock: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-      #     plan-parity: ${{ env.APPLY_TRIGGER && 'true' || 'false' }}
-      #     hide-args: true
-      #     plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+            Add the 'approved' label to apply the planned changes.
 
-      # - name: Assign approval label
-      #   if: ${{ env.PLAN_TRIGGER }}
-      #   run: |
-      #     gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #TODO: What to do when the plan is rejected
 
-      # - name: Update PR comment to request plan approval
-      #   if: ${{ env.PLAN_TRIGGER }}
-      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-      #   with:
-      #     header: tf-approval
-      #     message: |
-      #       #### Terraform Plan Approval required.
+      # This plan should not produce a diff
+      - name: Check idempotency
+        if: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
+        id: idempotency
+        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+        with:
+          working-directory: terraform/development
+          command: plan
+          arg-lock: false
+          hide-args: true
+          plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-      #       Add the 'approved' label to apply the planned changes.
+      - name: Add PR comment terraform diff
+        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: Diff Error
+          message: |
+            > [!WARNING]
+            > ${{ github.workflow }} detected a diff after a successful `terraform apply`
 
-      # #TODO: What to do when the plan is rejected
+            Please resolve the error and commit your changes to re-run the workflow.
 
-      # # This plan should not produce a diff
-      # - name: Check idempotency
-      #   if: ${{ env.APPLY_TRIGGER }}
-      #   id: idempotency
-      #   uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-      #   with:
-      #     working-directory: terraform/development
-      #     command: plan
-      #     arg-lock: false
-      #     hide-args: true
-      #     plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+            [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
 
-      # - name: Add PR comment terraform diff
-      #   if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-      #   uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-      #   with:
-      #     header: Diff Error
-      #     message: |
-      #       > [!WARNING]
-      #       > ${{ github.workflow }} detected a diff after a successful `terraform apply`
-
-      #       Please resolve the error and commit your changes to re-run the workflow.
-
-      #       [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
-
-      # - name: Diff Error
-      #   if: ${{ steps.idempotency.outputs.exitcode == 2 }}
-      #   run: |
-      #     exit 1
+      - name: Diff Error
+        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+        run: |
+          exit 1

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -186,11 +186,11 @@ jobs:
     steps:
       # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
       # Because the workflow is running in the issue_comment context the PR checks are not updated
-      - name: Update PR comment to request plan approval
+      - name: Update status comment
         if: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: tf-approval
+          header: status
           recreate: true
           message: |
             #### Terraform Plan Approved.
@@ -242,11 +242,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update PR comment to request plan approval
+      - name: Update status comment
         if: ${{ !(contains(github.event.pull_request.labels.*.name , 'approved')) }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: tf-approval
+          header: status
           message: |
             #### Terraform Plan Approval required.
 
@@ -266,20 +266,54 @@ jobs:
           hide-args: true
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
-      - name: Add PR comment terraform diff
+      - name: Update status comment
         if: ${{ steps.idempotency.outputs.exitcode == 2 }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          header: Diff Error
+          header: status
+          recreate: true
           message: |
             > [!WARNING]
             > ${{ github.workflow }} detected a diff after a successful `terraform apply`
 
             Please resolve the error and commit your changes to re-run the workflow.
 
-            [View log](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+            [View run log.](https://github.com/3ware/gitops-2024/actions/runs/${{ github.run_id }})
+
+      - name: Remove labels
+        if: ${{ steps.idempotency.outputs.exitcode == 2 }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "approved"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Diff Error
         if: ${{ steps.idempotency.outputs.exitcode == 2 }}
         run: |
           exit 1
+
+      - name: Update status comment
+        if: ${{ steps.idempotency.outputs.exitcode == 0 }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: status
+          recreate: true
+          message: |
+            #### Terraform apply successful :rocket:
+
+            <details><summary>Summary of changes.</summary>
+
+            ```diff
+            ${{ steps.terraform.outputs.diff }}
+            ```
+            </details>
+
+            <details><summary>${{ steps.terraform.outputs.summary }}</summary>
+
+            ```hcl
+            ${{ steps.terraform.outputs.result }}
+            ```
+
+            </details>
+
+            [View run log.](${{ steps.terraform.outputs.run-url }})

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   test-terraform:
-    if: ${{ github.event.label.name != 'approved' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name , 'approved') }}
     name: Test Terraform
     runs-on: ubuntu-latest
     permissions:
@@ -167,7 +167,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      github.event.label.name == 'approved' && needs.test-terraform.result == 'skipped'
+      contains(github.event.pull_request.labels.name, 'approved') && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.
@@ -177,9 +177,10 @@ jobs:
     environment: development
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      # Conditions that should evaluated to tru to run terraform apply
-      # Used in `if` conditions to trigger certain steps below or change arguments
-      APPLY_TRIGGER: ${{ github.event.label.name == 'approved' }}
+      # Run plan steps if the pull request does not have the 'approved' label
+      PLAN_TRIGGER: ${{ !contains(github.event.pull_request.labels.*.name , 'approved') }}
+      # Run apply steps if the pull request does not have the 'approved' label
+      APPLY_TRIGGER: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
 
     steps:
       # Assign the label and comment early in the workflow when approved to inform the user in the PR that something is happening
@@ -227,14 +228,14 @@ jobs:
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Assign approval label
-        if: ${{ github.event.label.name != 'approved' }}
+        if: ${{ env.PLAN_TRIGGER }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label "approval required"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR comment to request plan approval
-        if: ${{ github.event.label.name != 'approved' }}
+        if: ${{ env.PLAN_TRIGGER }}
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: tf-approval

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -50,71 +50,71 @@ resource "aws_route_table_association" "gitops_rta" {
   route_table_id = aws_route_table.gitops_rt.id
 }
 
-# resource "aws_security_group" "grafana_sg" {
-#   name        = "grafana_sg"
-#   description = "Grafana Server security group"
-#   vpc_id      = aws_vpc.gitops_vpc.id
-# }
+resource "aws_security_group" "grafana_sg" {
+  name        = "grafana_sg"
+  description = "Grafana Server security group"
+  vpc_id      = aws_vpc.gitops_vpc.id
+}
 
-# resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
-#   description       = "Inbound traffic to grafana web interface"
-#   security_group_id = aws_security_group.grafana_sg.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   from_port         = 3000
-#   ip_protocol       = "tcp"
-#   to_port           = 3000
+resource "aws_vpc_security_group_ingress_rule" "grafana_ingress" {
+  description       = "Inbound traffic to grafana web interface"
+  security_group_id = aws_security_group.grafana_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 3000
+  ip_protocol       = "tcp"
+  to_port           = 3000
 
-#   tags = {
-#     Name = "grafana-ingress-sg-rule-${local.environment}"
-#   }
+  tags = {
+    Name = "grafana-ingress-sg-rule-${local.environment}"
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# # trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
-# resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
-#   description       = "Outbound traffic from grafana server"
-#   security_group_id = aws_security_group.grafana_sg.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   ip_protocol       = "-1"
+# trunk-ignore(trivy/AVD-AWS-0104): Unrestricted egress traffic permitted for demo purposes
+resource "aws_vpc_security_group_egress_rule" "grafana_egress" {
+  description       = "Outbound traffic from grafana server"
+  security_group_id = aws_security_group.grafana_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
 
-#   tags = {
-#     Name = "grafana-egress-sg-rule-${local.environment}"
-#   }
+  tags = {
+    Name = "grafana-egress-sg-rule-${local.environment}"
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# data "aws_ami" "ubuntu" {
-#   most_recent = true
+data "aws_ami" "ubuntu" {
+  most_recent = true
 
-#   filter {
-#     name   = "name"
-#     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-#   }
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
 
-#   filter {
-#     name   = "virtualization-type"
-#     values = ["hvm"]
-#   }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 
-#   owners = ["099720109477"] # Canonical
-# }
+  owners = ["099720109477"] # Canonical
+}
 
-# # trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
-# # trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
-# resource "aws_instance" "grafana_server" {
-#   ami                    = data.aws_ami.ubuntu.id
-#   instance_type          = var.instance_type
-#   subnet_id              = aws_subnet.gitops_subnet.id
-#   vpc_security_group_ids = [aws_security_group.grafana_sg.id]
-#   user_data              = file("userdata.tftpl")
+# trunk-ignore(trivy/AVD-AWS-0028): IMDS token not required for demo
+# trunk-ignore(trivy/AVD-AWS-0131): EBS encryption not required for demo
+resource "aws_instance" "grafana_server" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.gitops_subnet.id
+  vpc_security_group_ids = [aws_security_group.grafana_sg.id]
+  user_data              = file("userdata.tftpl")
 
-#   tags = {
-#     Name = "grafana-server-${local.environment}"
-#   }
-# }
+  tags = {
+    Name = "grafana-server-${local.environment}"
+  }
+}

--- a/terraform/development/outputs.tf
+++ b/terraform/development/outputs.tf
@@ -9,7 +9,7 @@ output "default_tags" {
   value       = data.aws_default_tags.this.tags
 }
 
-# output "grafana_ip" {
-#   description = "The connection details of the grafana server."
-#   value       = "http://${aws_instance.grafana_server.public_ip}:3000"
-# }
+output "grafana_ip" {
+  description = "The connection details of the grafana server."
+  value       = "http://${aws_instance.grafana_server.public_ip}:3000"
+}

--- a/terraform/development/terraform.tfvars
+++ b/terraform/development/terraform.tfvars
@@ -1,4 +1,4 @@
-# instance_type     = "t2.micro"
+instance_type     = "t2.micro"
 project_id        = "gitops-2024"
 region            = "us-east-1"
 subnet_cidr_block = "10.0.2.0/24"

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -1,21 +1,21 @@
-# locals {
-#   valid_instance_types = ["t2.micro"]
-# }
+locals {
+  valid_instance_types = ["t2.micro"]
+}
 
-# variable "instance_type" {
-#   description = "(Required) Instance type to use. Should be within the free tier"
-#   type        = string
+variable "instance_type" {
+  description = "(Required) Instance type to use. Should be within the free tier"
+  type        = string
 
-#   validation {
-#     condition = contains(local.valid_instance_types, var.instance_type)
-#     error_message = format(
-#       "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
-#       var.instance_type,
-#       join(", ", local.valid_instance_types),
-#       "Change the instance type variable to one that is permitted."
-#     )
-#   }
-# }
+  validation {
+    condition = contains(local.valid_instance_types, var.instance_type)
+    error_message = format(
+      "Invalid instance type provided. Received: '%s', Require: '%v'.\n%s",
+      var.instance_type,
+      join(", ", local.valid_instance_types),
+      "Change the instance type variable to one that is permitted."
+    )
+  }
+}
 
 variable "project_id" {
   description = "(Required) Name of the project"


### PR DESCRIPTION
`issue_comment` trigger runs on the default branch causing failed applies due to stale plans. See (https://github.com/3ware/gitops-2024/actions/runs/11461949287)


Switching to `pull_request.labeled` so everything runs on the PR branch.