### PR TITLE
feat(terraform): simplify tf-via-pr inputs

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -226,9 +226,7 @@ jobs:
           working-directory: terraform/development
           # If the 'approved' label exits, run 'apply'; if it doesn't run 'plan'
           command: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'apply' || 'plan' }}
-          arg-lock: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
-          # plan-parity: ${{ contains(github.event.pull_request.labels.*.name , 'approved') && 'true' || 'false' }}
-          hide-args: true
+          arg-lock: ${{ contains(github.event.pull_request.labels.*.name , 'approved') }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
 
       - name: Assign approval label
@@ -259,7 +257,6 @@ jobs:
           working-directory: terraform/development
           command: plan
           arg-lock: false
-          hide-args: true
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
           comment-pr: none
 


### PR DESCRIPTION
- `arg-lock` comparison returns `true` or `false`, so it doesn't need to be explicitly defined.
- `hide-args` isn't a boolean as much as a comma-separated list of args to be hidden from the "command input" header of the PR comment ([docs](https://github.com/DevSecTop/TF-via-PR#:~:text=Hide%20comma%2Dseparated%20arguments%20from%20the%20command%20input)). It's set to `detailed-exitcode,lock,out,var` by default, so can be ignored for the most part.

Happened to come across this [from here](https://github.com/DevSecTop/TF-via-PR/issues/337).