### PR TITLE
ci(terraform): update tf-via-pr reference

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -209,7 +209,7 @@ prdPlan -->|Approve PR|TFPass
 #### Actions Used
 
 - [changed-files](https://github.com/tj-actions/changed-files)
-- [TF-via-PR](https://github.com/DevSecTop/TF-via-PR)
+- [TF-via-PR](https://github.com/OP5dev/TF-via-PR)
 - [Infracost](https://github.com/infracost/infracost)
 - [Setup Terraform](https://github.com/hashicorp/setup-terraform/commits/main/)
 - [Setup TFLint](https://github.com/terraform-linters/setup-tflint)
@@ -248,7 +248,7 @@ Uses a matrix strategy to run in each directory identified in the targets job.
 
 ##### Plan
 
-When the validation steps have succeeded - a ` terraform plan` will be run. The conditional statement runs `plan` on a `pull_request` event. The workflow uses [TF-via-PR](https://github.com/DevSecTop/TF-via-PR). This action adds a high level plan and detailed drop down style plan to the workflow summary and updates the pull request with a comment.
+When the validation steps have succeeded - a ` terraform plan` will be run. The conditional statement runs `plan` on a `pull_request` event. The workflow uses [TF-via-PR](https://github.com/OP5dev/TF-via-PR). This action adds a high level plan and detailed drop down style plan to the workflow summary and updates the pull request with a comment.
 
 ##### Apply
 
@@ -277,4 +277,4 @@ Generate a CHANGELOG and version tag using [semantic release](https://github.com
 
 ## Contributions
 
-- Special mention to the maintainer of [TF-via-PR](https://github.com/DevSecTop/TF-via-PR) for responding to queries quickly and proactively suggesting workflow improvements.
+- Special mention to the maintainer of [TF-via-PR](https://github.com/OP5dev/TF-via-PR) for responding to queries quickly and proactively suggesting workflow improvements.

--- a/.github/workflows/drift-detection.yaml
+++ b/.github/workflows/drift-detection.yaml
@@ -38,7 +38,7 @@ jobs:
           role-session-name: gitops2024-development-terraform-deploy
 
       - name: Terraform Plan
-        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+        uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
         id: drift-plan
         with:
           working-directory: terraform/development

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -208,7 +208,7 @@ jobs:
             #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
 
       - name: Provision TF
-        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
+        uses: op5dev/tf-via-pr@f455e10e6e83d28f53f505a2d8242433a17536f3 # v13.0.0
         with:
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -214,4 +214,3 @@ jobs:
           arg-lock: ${{ github.event_name == 'merge_group' }}
           working-directory: ${{ matrix.targets }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
-          comment-pr: recreate


### PR DESCRIPTION
Following name change, update references from [DevSecTop to OP5dev](https://github.com/OP5dev/TF-via-PR/releases/tag/v13.0.0).