### PR TITLE
ci(renovate): Enable TFLint plugin updates

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,5 @@
-module.exports = {
-  rules: {
+{
+  "rules": {
     "body-leading-blank": [1, "always"],
     "body-max-line-length": [2, "always", 72],
     "footer-leading-blank": [1, "always"],
@@ -8,24 +8,23 @@ module.exports = {
     "scope-case": [2, "always", "lower-case"],
     "scope-empty": [1, "never"],
     "scope-enum": [
-      1,
+      2,
       "always",
       [
         "checks",
         "commitlint",
         "drift",
+        "iac",
         "infracost",
         "pr-check",
-        "renbot",
+        "renovate",
         "release",
         "repo",
-        "terraform",
         "terraform-ci",
         "terraform-docs",
-        "trunk",
-      ],
+        "trunk"
+      ]
     ],
-    //"signed-off-by": [1, "always", "Signed-off-by:"],
     "subject-case": [1, "always", "sentence-case"],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
@@ -45,8 +44,8 @@ module.exports = {
         "refactor",
         "revert",
         "style",
-        "test",
-      ],
-    ],
-  },
-};
+        "test"
+      ]
+    ]
+  }
+}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessageLowerCase": "never",
+  "extends": ["security:only-security-updates"],
+  "enabledManagers": ["terraform", "tflint-plugin"],
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"],
+      "registryUrls": ["https://registry.opentofu.org"],
+      "enabled": true,
+      "addLabels": ["tf-update"],
+      "minimumReleaseAge": "3 days",
+      "commitMessagePrefix": "feat({{depName}}): ",
+      "commitMessageTopic": "{{depName}} provider"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"],
+    "commitMessagePrefix": "fix(deps): ",
+    "rangeStrategy": "auto"
+  }
+}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -14,6 +14,12 @@
       "commitMessageTopic": "{{depName}} provider"
     }
   ],
+  "tflint-plugin": {
+    "enabled": true,
+    "fileMatch": ["\\.tflint\\.hcl$", "\\.tflint_(ci|trunk)\\.hcl$"],
+    "minimumReleaseAge": "3 days",
+    "commitMessagePrefix": "feat({{depName}}): "
+  },
   "vulnerabilityAlerts": {
     "addLabels": ["security"],
     "commitMessagePrefix": "fix(deps): ",

--- a/.trunk/configs/.tflint_ci.hcl
+++ b/.trunk/configs/.tflint_ci.hcl
@@ -1,12 +1,17 @@
+# TFLint configuration file for CI/CD pipelines
 plugin "terraform" {
   enabled = true
   preset = "all"
 }
 
+Enable the AWS plugin if required
 plugin "aws" {
   enabled = true
   version = "0.33.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 
+  # Deep check can be enabled in CI/CD pipelines, where AWS credentials are set
+  # This configuration file should be references using the `--config` flag
+  # Example: https://github.com/3ware/aws-network-speciality/blob/79a2be0813e053f17ed4f802705f7b6f2c350f0d/.github/workflows/terraform-ci.yaml#L114
   deep_check = true
 }

--- a/.trunk/configs/.tflint_trunk.hcl
+++ b/.trunk/configs/.tflint_trunk.hcl
@@ -1,3 +1,4 @@
+# TFLint configuration file for Trunk CLI
 plugin "terraform" {
   enabled = true
   preset = "all"
@@ -8,6 +9,7 @@ plugin "aws" {
   version = "0.33.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 
-  # Disabled for trunk because VSCode fails to prepare the workspace with AWS env vars enabled
+  # Deep check disabled for Trunk CLI because VSCode fails to prepare the workspace with
+  # AWS credential environment variables set
   deep_check = false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["tflint-plugin"],
-  "minimumReleaseAge": "3 days",
-  "addLabels": ["auto-update"],
-  "schedule": ["before 4am on the first day of the month"]
-}


### PR DESCRIPTION
TFLint has more than one configuration file because of differences running locally, via the trunk CLI / VSCode extension, and running in a pipeline via GitHub Actions.

The default [`fileMatch`](https://docs.renovatebot.com/modules/manager/tflint-plugin/) for TFLint plugin updates does not match these filenames.

The `fileMatch` pattern has been updated to cater for the `_ci` and `_trunk` suffixes.