### PR TITLE
ci(renovate): Enable `github-releases` data source

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -12,6 +12,10 @@
       "minimumReleaseAge": "3 days",
       "commitMessagePrefix": "feat({{depName}}): ",
       "commitMessageTopic": "{{depName}} provider"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "enabled": true
     }
   ],
   "tflint-plugin": {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -16,7 +16,7 @@
   ],
   "tflint-plugin": {
     "enabled": true,
-    "fileMatch": ["\\.tflint\\.hcl$", "\\.tflint_(ci|trunk)\\.hcl$"],
+    "fileMatch": ["\\.tflint_(ci|trunk)\\.hcl$"],
     "minimumReleaseAge": "3 days",
     "commitMessagePrefix": "feat({{depName}}): "
   },


### PR DESCRIPTION
This data source is required to update TFLint plugins.