### PR TITLE
ci(renovate): Enable terraform version updates

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -22,6 +22,7 @@
         "repo",
         "terraform-ci",
         "terraform-docs",
+        "tflint",
         "trunk"
       ]
     ],

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -39,7 +39,9 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: 2
-          files: terraform/**
+          files: |
+            terraform/**
+            **/.hcl
           matrix: true
 
   terraform-deploy:

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,7 +22,8 @@
     "enabled": true,
     "fileMatch": ["\\.tflint_(ci|trunk)\\.hcl$"],
     "minimumReleaseAge": "3 days",
-    "commitMessagePrefix": "feat({{depName}}): "
+    "commitMessagePrefix": "feat(tflint): ",
+    "commitMessageTopic": "{{depName}}"
   },
   "vulnerabilityAlerts": {
     "addLabels": ["security"],

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "addLabels": ["tf-update"],
       "minimumReleaseAge": "3 days",
-      "commitMessagePrefix": "feat({{depName}}): ",
+      "commitMessagePrefix": "feat(iac): ",
       "commitMessageTopic": "{{depName}} provider"
     },
     {

--- a/terraform/development/versions.tf
+++ b/terraform/development/versions.tf
@@ -1,10 +1,11 @@
 terraform {
   # Must be above 1.9.0 to allow cross-object referencing for input variable validations
-  required_version = ">=1.9.0, < 2.0.0"
+  # `~> 1.9` means any version greater than or equal to 1.9 but less than 2.0
+  required_version = "~> 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.69.0"
+      version = "~> 5.69.0"
     }
     # http = {
     #   source  = "hashicorp/http"

--- a/terraform/production/versions.tf
+++ b/terraform/production/versions.tf
@@ -1,10 +1,11 @@
 terraform {
   # Must be above 1.9.0 to allow cross-object referencing for input variable validations
-  required_version = ">=1.9.0, < 2.0.0"
+  # `~> 1.9` means any version greater than or equal to 1.9 but less than 2.0
+  required_version = "~> 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.69.0"
+      version = "~> 5.69.0"
     }
     # http = {
     #   source  = "hashicorp/http"


### PR DESCRIPTION
Provider updates and TFLint plugin updates are generating PRs, but terraform version updates are not. I suspect this is because renovate does not recognise `<` as a valid version constraint pattern:

https://docs.renovatebot.com/modules/manager/terraform/#range-constraints

> 
| Terraform range | Notes |
| -- | -- |
| >= 1.2.0 | version 1.2.0 or newer | 
| <= 1.2.0 | version 1.2.0 or older |
| ~> 1.2.0 | any non-beta version >= 1.2.0 and < 1.3.0, e.g. 1.2.X |
| ~> 1.2 | any non-beta version >= 1.2.0 and < 2.0.0, e.g. 1.X.Y |
| >= 1.0.0, <= 2.0.0 | any version between 1.0.0 and 2.0.0 inclusive |

`required_version` blocks have been updated with the constraint: `"~>1.9"` removing the patch digit, allowing minor version updates, but not major version updates.
