### PR TITLE
ci(renovate): Enable terraform version updates v2

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -18,6 +18,12 @@
       "enabled": true
     }
   ],
+  "terraform": {
+    "enabled": true,
+    "minimumReleaseAge": "3 days",
+    "commitMessagePrefix": "feat(iac): ",
+    "commitMessageTopic": "{{depName}}"
+  },
   "tflint-plugin": {
     "enabled": true,
     "fileMatch": ["\\.tflint_(ci|trunk)\\.hcl$"],


### PR DESCRIPTION
Previous PR did not trigger a version update, I'm expecting to update to v1.11.0. See renovate job logs:

```
{
            "currentValue": "~> 1.9",
            "depType": "required_version",
            "datasource": "github-releases",
            "depName": "hashicorp/terraform",
            "extractVersion": "v(?<version>.*)$",
            "versioning": "hashicorp",
            "updates": [],
            "packageName": "hashicorp/terraform",
            "warnings": [],
            "sourceUrl": "https://github.com/hashicorp/terraform",
            "registryUrl": "https://github.com",
            "currentVersion": "1.11.0",
            "currentVersionTimestamp": "2025-02-27T13:26:05.000Z",
            "currentVersionAgeInDays": 0
          }
        ],
        "packageFile": "terraform/production/versions.tf"
```

`terraform` has been explicitly enabled in the renovate configuration.