### PR TITLE
ci(renovate): Add bump rangeStrategy to terraform manager

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -16,6 +16,7 @@
     //"minimumReleaseAge": "3 days",
     "commitMessagePrefix": "feat(iac): ",
     "commitMessageTopic": "{{depName}}",
+    // bump required because v1.11.0, for example, satisfies the range "~> 1.9"
     "rangeStrategy": "bump"
   },
   "tflint-plugin": {

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -15,7 +15,8 @@
     "enabled": true,
     //"minimumReleaseAge": "3 days",
     "commitMessagePrefix": "feat(iac): ",
-    "commitMessageTopic": "{{depName}}"
+    "commitMessageTopic": "{{depName}}",
+    "rangeStrategy": "bump"
   },
   "tflint-plugin": {
     "enabled": true,

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -9,6 +9,25 @@
     "terraform",
     "tflint-plugin"
   ],
+  // manager block. fileMatch must be configured here and not in packageRules because
+  // packageRules can matchManagers
+  "terraform": {
+    "enabled": true,
+    //"minimumReleaseAge": "3 days",
+    "commitMessagePrefix": "feat(iac): ",
+    "commitMessageTopic": "{{depName}}"
+  },
+  "tflint-plugin": {
+    "enabled": true,
+    "fileMatch": [
+      // match all .tflint_ci.hcl and .tflint_trunk.hcl files
+      // 'ci' and 'trunk' have different configurations
+      "\\.tflint_(ci|trunk)\\.hcl$"
+    ],
+    "minimumReleaseAge": "3 days",
+    "commitMessagePrefix": "feat(tflint): ",
+    "commitMessageTopic": "{{depName}}"
+  },
   "packageRules": [
     {
       // datasources look up dependency versions from a registry
@@ -37,23 +56,6 @@
       "enabled": true
     }
   ],
-  "terraform": {
-    "enabled": true,
-    //"minimumReleaseAge": "3 days",
-    "commitMessagePrefix": "feat(iac): ",
-    "commitMessageTopic": "{{depName}}"
-  },
-  "tflint-plugin": {
-    "enabled": true,
-    "fileMatch": [
-      // match all .tflint_ci.hcl and .tflint_trunk.hcl files
-      // 'ci' and 'trunk' have different configurations
-      "\\.tflint_(ci|trunk)\\.hcl$"
-    ],
-    "minimumReleaseAge": "3 days",
-    "commitMessagePrefix": "feat(tflint): ",
-    "commitMessageTopic": "{{depName}}"
-  },
   "vulnerabilityAlerts": {
     "addLabels": [
       "security"


### PR DESCRIPTION
From the logs you can see that terraform `required_versions` uses the hashicorp versioning module: https://docs.renovatebot.com/modules/versioning/hashicorp/ which does not support all range strategy behaviours:

> Valid rangeStrategy values are: bump, widen, pin, replace

I have selected `bump` for terraform: the documentation (https://docs.renovatebot.com/configuration-options/#rangestrategy) indicates that values like `"~> 1.9"` will not be updated with newer versions like `v1.11.0` because this newer version satisfies the range. `bump` should be used to update the version constraint:

> For example, if your package.json specifies a value for left-pad of ^1.0.0 and the latest version on npmjs is 1.2.0, then Renovate won't change anything because 1.2.0 satisfies the range. If instead you'd prefer to be updated to ^1.2.0 in cases like this, then configure rangeStrategy to bump in your Renovate config.
