### PR TITLE
ci(trunk): Use head_ref for concurrency group

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -12,7 +12,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Previous concurrency group setting was causing a clash between pull requests. 🤦