### PR TITLE
ci(pr-check): Add auto-approve-pr job

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -18,6 +18,7 @@
         "gha",
         "iac",
         "infracost",
+        "labeler",
         "pr-check",
         "renovate",
         "release",

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,3 +1,4 @@
 auto-approve:
-  - base-branch: [main]
-  - head-branch: ["project/[a-z]+-config", trunk-io/update-trunk]
+  - all:
+      - base-branch: [main]
+      - head-branch: ["project/[a-z]+-config"]

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -42,8 +42,19 @@ jobs:
 
   enforce-all-checks:
     name: Checks
-    #needs: [validate-pr-title]
     permissions:
       checks: read
     uses: 3ware/workflows/.github/workflows/wait-for-checks.yaml@ref/auto-approve # 4.14.1
     secrets: inherit
+
+  auto-approve-pr:
+    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'auto-approve') }}
+    needs: [enforce-all-checks]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Auto Approve PR
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        with:
+          github-token: ${{ secrets.PR_APPROVAL_PAT }}
+          review-message: All checks passed. Auto Approved.

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -50,9 +50,13 @@ jobs:
   auto-approve-pr:
     if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'auto-approve') }}
     needs: [enforce-all-checks]
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Dump PR event
+        run: echo "${{ toJson(github.event) }}"
       - name: Auto Approve PR
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:


### PR DESCRIPTION
auto-approve-pr was called from the checks reusable workflow. Both pr-title and checks ran concurrently so labels were not applied when the auto-approve job ran.

Adding as a separate job, that runs after checks, should get pr event data with labels applied.